### PR TITLE
[Sumtree]: Update Tick Pointers

### DIFF
--- a/contracts/sumtree-orderbook/src/tests/test_order.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_order.rs
@@ -609,9 +609,9 @@ struct RunMarketOrderTestCase {
     tick_bound: i64,
     orders: Vec<LimitOrder>,
     sent: Uint128,
-
     expected_output: Uint128,
     expected_tick_etas: Vec<(i64, Decimal256)>,
+    expected_tick_pointers: Vec<(OrderDirection, i64)>,
     expected_error: Option<ContractError>,
 }
 
@@ -656,6 +656,7 @@ fn test_run_market_order() {
                 -1500000,
                 Decimal256::from_ratio(Uint128::new(850), Uint128::one()),
             )],
+            expected_tick_pointers: vec![(OrderDirection::Ask, -1500000)],
             expected_error: None,
         },
         RunMarketOrderTestCase {
@@ -690,6 +691,7 @@ fn test_run_market_order() {
                 40000000,
                 Decimal256::from_ratio(Uint128::new(50_000_000), Uint128::one()),
             )],
+            expected_tick_pointers: vec![(OrderDirection::Ask, 40000000)],
             expected_error: None,
         },
         RunMarketOrderTestCase {
@@ -725,6 +727,7 @@ fn test_run_market_order() {
                 -17765433,
                 Decimal256::from_ratio(Uint128::new(12), Uint128::one()),
             )],
+            expected_tick_pointers: vec![(OrderDirection::Ask, -17765433)],
             expected_error: None,
         },
         RunMarketOrderTestCase {
@@ -771,6 +774,7 @@ fn test_run_market_order() {
                     Decimal256::from_ratio(Uint128::new(500), Uint128::one()),
                 ),
             ],
+            expected_tick_pointers: vec![(OrderDirection::Ask, 40000000)],
             expected_error: None,
         },
         RunMarketOrderTestCase {
@@ -805,6 +809,7 @@ fn test_run_market_order() {
                 40000000,
                 Decimal256::from_ratio(Uint128::new(2), Uint128::one()),
             )],
+            expected_tick_pointers: vec![(OrderDirection::Bid, 40000000)],
             expected_error: None,
         },
         RunMarketOrderTestCase {
@@ -840,6 +845,7 @@ fn test_run_market_order() {
                 -17765433,
                 Decimal256::from_ratio(Uint128::new(81_000), Uint128::one()),
             )],
+            expected_tick_pointers: vec![(OrderDirection::Bid, -17765433)],
             expected_error: None,
         },
         RunMarketOrderTestCase {
@@ -864,6 +870,7 @@ fn test_run_market_order() {
 
             expected_output: Uint128::zero(),
             expected_tick_etas: vec![(10, Decimal256::zero())],
+            expected_tick_pointers: vec![(OrderDirection::Ask, 10)],
             expected_error: Some(ContractError::InvalidBookId {
                 book_id: invalid_book_id,
             }),
@@ -888,6 +895,7 @@ fn test_run_market_order() {
             ),
             expected_output: Uint128::zero(),
             expected_tick_etas: vec![(10, Decimal256::zero())],
+            expected_tick_pointers: vec![(OrderDirection::Ask, 10)],
             expected_error: Some(ContractError::InvalidTickId {
                 tick_id: MIN_TICK - 1,
             }),
@@ -912,6 +920,7 @@ fn test_run_market_order() {
             ),
             expected_output: Uint128::zero(),
             expected_tick_etas: vec![(10, Decimal256::zero())],
+            expected_tick_pointers: vec![(OrderDirection::Bid, MIN_TICK)],
             expected_error: Some(ContractError::InvalidTickId {
                 tick_id: MAX_TICK + 1,
             }),
@@ -942,6 +951,7 @@ fn test_run_market_order() {
 
             expected_output: Uint128::zero(),
             expected_tick_etas: vec![(-1500000, Decimal256::zero())],
+            expected_tick_pointers: vec![(OrderDirection::Ask, -1500000)],
             expected_error: Some(ContractError::InvalidTickId { tick_id: MIN_TICK }),
         },
         RunMarketOrderTestCase {
@@ -978,6 +988,7 @@ fn test_run_market_order() {
                 40000000,
                 Decimal256::from_ratio(Uint128::new(25_000_000), Uint128::one()),
             )],
+            expected_tick_pointers: vec![(OrderDirection::Ask, 40000000)],
             expected_error: None,
         },
     ];
@@ -1048,6 +1059,18 @@ fn test_run_market_order() {
                 "{}",
                 format_test_name(test.name)
             );
+        }
+
+        // Assert orderbook tick pointers were updated as expected
+        let post_process_orderbook = ORDERBOOKS
+            .load(deps.as_ref().storage, &valid_book_id)
+            .unwrap();
+        for (direction, tick_id) in test.expected_tick_pointers {
+            let pointer = match direction {
+                OrderDirection::Ask => post_process_orderbook.next_ask_tick,
+                OrderDirection::Bid => post_process_orderbook.next_bid_tick,
+            };
+            assert_eq!(tick_id, pointer, "{}", format_test_name(test.name));
         }
 
         // Regardless of whether we error, orders should not be modified.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #101 

## What is the purpose of the change
These changes implement updating `next_*_tick` fields in the `Orderbook` struct as a market order is filled. Anytime a tick is visited during the process the appropriate pointer is updated to match the current visited tick (even if nothng is filled). In the case that the tick does not fill anything from the market order we still update the pointer as it implies the previous tick was fully filled and this covers an edge case where a new order perfectly fills a tick.

An early escape clause was also added to the logic to finish visiting nodes once the market order has been filled.

## Testing and Verifying
An extra check was added to `test_run_market_order` to check the expected pointers post fill logic.