### PR TITLE
[Sumtree]: Rremove partial cancel TODO

### DIFF
--- a/contracts/sumtree-orderbook/src/order.rs
+++ b/contracts/sumtree-orderbook/src/order.rs
@@ -170,8 +170,6 @@ pub fn cancel_limit(
     ensure_eq!(info.sender, order.owner, ContractError::Unauthorized {});
 
     // Ensure the order has not been filled.
-    // TODO: support cancelling partially filled orders by claiming above
-    // if a partial fill is detected. Tracked in issue https://github.com/osmosis-labs/orderbook/issues/75
     let tick_state = TICK_STATE
         .load(deps.storage, &(book_id, tick_id))
         .unwrap_or_default();


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #75

## What is the purpose of the change

Removes TODO for partial cancels (see #75 for context).

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.
