### PR TITLE
[Sumtree]: Add check to error if orderbook runs out of liquidity

### DIFF
--- a/contracts/sumtree-orderbook/src/contract.rs
+++ b/contracts/sumtree-orderbook/src/contract.rs
@@ -132,7 +132,6 @@ pub fn reply(_deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, Contract
     todo!()
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn dispatch_place_limit(
     mut deps: DepsMut,
     env: Env,

--- a/contracts/sumtree-orderbook/src/error.rs
+++ b/contracts/sumtree-orderbook/src/error.rs
@@ -94,7 +94,7 @@ pub enum ContractError {
     NodeInsertionError,
 
     #[error("Orderbook ran out of liquidity during market order")]
-    InsufficientOrderbookLiquidity,
+    InsufficientLiquidity,
 
     #[error("Claim bounty must be a value between 0 and 1. Received: {claim_bounty:?}")]
     InvalidClaimBounty { claim_bounty: Option<Decimal> },

--- a/contracts/sumtree-orderbook/src/tests/test_order.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_order.rs
@@ -987,40 +987,35 @@ fn test_run_market_order() {
             expected_tick_pointers: vec![(OrderDirection::Ask, -1500000)],
             expected_error: Some(ContractError::InvalidTickId { tick_id: MIN_TICK }),
         },
-        // RunMarketOrderTestCase {
-        //     name: "bid at positive tick that can only partially be filled",
-        //     sent: Uint128::new(1000),
-        //     placed_order: MarketOrder::new(
-        //         valid_book_id,
-        //         Uint128::new(1000),
-        //         OrderDirection::Bid,
-        //         Addr::unchecked(default_sender),
-        //     ),
-        //     tick_bound: MAX_TICK,
+        RunMarketOrderTestCase {
+            name: "insufficient liquidity on orderbook",
+            sent: Uint128::new(1000),
+            placed_order: MarketOrder::new(
+                valid_book_id,
+                // Only 973 can be filled
+                Uint128::new(1000),
+                OrderDirection::Bid,
+                Addr::unchecked(default_sender),
+            ),
+            tick_bound: MAX_TICK,
 
-        //     // Orders to fill against
-        //     orders: generate_limit_orders(
-        //         valid_book_id,
-        //         &[40000000],
-        //         // Current tick is below the active limit orders
-        //         default_current_tick,
-        //         // Only half the required liquidity to process the full input.
-        //         1,
-        //         Uint128::new(25_000_000),
-        //     ),
+            // Orders to fill against
+            orders: generate_limit_orders(
+                valid_book_id,
+                &[-17765433],
+                // Current tick is below the active limit orders
+                -20000000,
+                // Four limit orders with sufficient total liquidity to process the
+                // full market order
+                4,
+                Uint128::new(3),
+            ),
 
-        //     // Bidding 1000 units of input into tick 40,000,000, which corresponds to a
-        //     // price of $50000 (from tick math test cases).
-        //     //
-        //     // This implies 1000*50000 = 50,000,000 units of output.
-        //     //
-        //     // However, since the book only has 25,000,000 units of liquidity, that is how much
-        //     // is filled.
-        //     expected_output: Uint128::new(25_000_000),
-        //     expected_tick_etas: vec![(40000000, decimal256_from_u128(Uint128::new(25_000_000)))],
-        //     expected_tick_pointers: vec![(OrderDirection::Ask, 40000000)],
-        //     expected_error: None,
-        // },
+            expected_output: Uint128::zero(),
+            expected_tick_etas: vec![],
+            expected_tick_pointers: vec![],
+            expected_error: Some(ContractError::InsufficientLiquidity {}),
+        },
     ];
 
     for test in test_cases {

--- a/contracts/sumtree-orderbook/src/tick_math.rs
+++ b/contracts/sumtree-orderbook/src/tick_math.rs
@@ -150,6 +150,9 @@ pub fn amount_to_value(
     price: Decimal256,
     rounding_direction: RoundingDirection,
 ) -> ContractResult<Uint128> {
+    if amount.is_zero() {
+        return Ok(Uint128::zero());
+    }
     match order {
         OrderDirection::Bid => multiply_by_price(amount, price, rounding_direction),
         OrderDirection::Ask => divide_by_price(amount, price, rounding_direction),

--- a/contracts/sumtree-orderbook/src/types/order.rs
+++ b/contracts/sumtree-orderbook/src/types/order.rs
@@ -48,7 +48,6 @@ pub struct LimitOrder {
     pub claim_bounty: Option<Decimal>,
 }
 
-#[allow(clippy::too_many_arguments)]
 impl LimitOrder {
     pub fn new(
         book_id: u64,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #118, #127

## What is the purpose of the change

This PR adds an error if a  market order is not fully filled.

## Testing and Verifying

Tests are updated/added in `test_order.rs`