### PR TITLE
[Sumtree]: Implement 1% cap for claim bounty

### DIFF
--- a/contracts/sumtree-orderbook/src/error.rs
+++ b/contracts/sumtree-orderbook/src/error.rs
@@ -96,7 +96,7 @@ pub enum ContractError {
     #[error("Orderbook ran out of liquidity during market order")]
     InsufficientLiquidity,
 
-    #[error("Claim bounty must be a value between 0 and 1. Received: {claim_bounty:?}")]
+    #[error("Claim bounty must be a value between 0 and 0.01 (1%). Received: {claim_bounty:?}")]
     InvalidClaimBounty { claim_bounty: Option<Decimal> },
 }
 

--- a/contracts/sumtree-orderbook/src/order.rs
+++ b/contracts/sumtree-orderbook/src/order.rs
@@ -44,10 +44,11 @@ pub fn place_limit(
         ContractError::InvalidQuantity { quantity }
     );
 
-    // If applicable, ensure claim_bounty is between 0 and 1
+    // If applicable, ensure claim_bounty is between 0 and 0.01.
+    // We set a conservative upper bound of 1% for claim bounties as a guardrail.
     if let Some(claim_bounty_value) = claim_bounty {
         ensure!(
-            claim_bounty_value >= Decimal::zero() && claim_bounty_value <= Decimal::one(),
+            claim_bounty_value >= Decimal::zero() && claim_bounty_value <= Decimal::percent(1),
             ContractError::InvalidClaimBounty {
                 claim_bounty: Some(claim_bounty_value)
             }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #128

## What is the purpose of the change

This PR implements a 1% cap for claim bounties (see issue for motivation and discussion).

## Testing and Verifying

This change is tested in `test_order.rs`