### PR TITLE
[Sumtree]: Split Function Explicit Ordering

### DIFF
--- a/contracts/sumtree-orderbook/src/sumtree/node.rs
+++ b/contracts/sumtree-orderbook/src/sumtree/node.rs
@@ -556,11 +556,11 @@ impl TreeNode {
         let accumulator = self.get_value().checked_add(new_node.get_value())?;
 
         // Determine which node goes to which side, maintaining order by ETAS
-        let (new_left, new_right) = if self.get_max_range() <= new_node.get_min_range() {
-            // New node is higher than current node
+        let (new_left, new_right) = if self.below_range(new_node.clone()) {
+            // Current node is below new node
             (self.key, new_node.key)
-        } else if self.get_min_range() >= new_node.get_max_range() {
-            // New node is lower than current node
+        } else if self.above_range(new_node.clone()) {
+            // Current node is above new node
             (new_node.key, self.key)
         } else {
             // New node overlap the current node creating an invalid sumtree


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #70 

## What is the purpose of the change
This change adds an explicit error condition to the sumtree node's `split` function. There is an edge case where a newly inserted node may overlap with the node that is being split (causing an erroneous sumtree). These changes add an error condition for this case.

## Testing and Verifying
No tests were updated/added.