### PR TITLE
[fix]: Implement and test freeze fix

### DIFF
--- a/contracts/sumtree-orderbook/src/sudo.rs
+++ b/contracts/sumtree-orderbook/src/sudo.rs
@@ -19,6 +19,9 @@ use crate::{
 
 #[cfg_attr(not(feature = "imported"), entry_point)]
 pub fn sudo(deps: DepsMut, env: Env, msg: SudoMsg) -> ContractResult<Response> {
+    // Ensure orderbook is active
+    ensure_is_active(deps.as_ref())?;
+
     match msg {
         SudoMsg::SwapExactAmountIn {
             sender,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #184

## What is the purpose of the change

This PR increases freeze scope to include sudo messages, which are accessible by through the CW pool interface.

## Testing and Verifying

Tests can be found in `test_sudo.rs`