### PR TITLE
[Sumtree]: Wire up maker fee related constants

### DIFF
--- a/contracts/sumtree-orderbook/src/constants.rs
+++ b/contracts/sumtree-orderbook/src/constants.rs
@@ -10,6 +10,22 @@ pub const EXPECTED_SWAP_FEE: Decimal = Decimal::zero();
 pub const MAX_BATCH_CLAIM: u32 = 100;
 pub const MAX_MAKER_FEE_PERCENTAGE: Decimal256 = Decimal256::percent(5);
 
+// Address controlled by Osmosis governance
+pub const OSMOSIS_GOV_ADDR: &str = "osmo10d07y265gmmuvt4z0w9aw880jnsr700jjeq4qp";
+
+// Circuit breaker is set up as a DAODAO subDAO that can be found here:
+// https://daodao.zone/dao/osmo1peuxfjj66n2qt2v5jmqlvzz8neakjgduez7vttvemw58uug6546sr60ngl/home
+pub const CIRCUIT_BREAKER_SUBDAO_ADDR: &str =
+    "osmo1peuxfjj66n2qt2v5jmqlvzz8neakjgduez7vttvemw58uug6546sr60ngl";
+
+// By default, the maker fee recipient is set to be the same module address that
+// taker fees are sent to. This can be changed by governance through the governance-controlled
+// wallet set as admin.
+pub const DEFAULT_MAKER_FEE_RECIPIENT: &str = "osmo1r9jc2234fljy93z80cevqjt3nmjycec8aj4cc6";
+
+// By default, the maker fee is set to zero. This can be updated by governance.
+pub const DEFAULT_MAKER_FEE: Decimal256 = Decimal256::zero();
+
 // TODO: optimize this using lazy_static
 pub fn max_spot_price() -> Decimal256 {
     Decimal256::from_str("340282300000000000000").unwrap()

--- a/contracts/sumtree-orderbook/src/contract.rs
+++ b/contracts/sumtree-orderbook/src/contract.rs
@@ -7,6 +7,7 @@ use cosmwasm_std::{
 use cw2::set_contract_version;
 
 use crate::auth::{ADMIN, MODERATOR};
+use crate::constants::{CIRCUIT_BREAKER_SUBDAO_ADDR, OSMOSIS_GOV_ADDR};
 use crate::error::{ContractError, ContractResult};
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 
@@ -28,12 +29,16 @@ pub fn instantiate(
     _info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
+    // Set contract metadata
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-    let admin = deps.api.addr_validate(msg.admin.as_str())?;
+
+    // Set contract admin to governance and moderator to circuit breaker subDAO
+    let admin = deps.api.addr_validate(OSMOSIS_GOV_ADDR)?;
     ADMIN.save(deps.storage, &admin)?;
-    let moderator = deps.api.addr_validate(msg.moderator.as_str())?;
+    let moderator = deps.api.addr_validate(CIRCUIT_BREAKER_SUBDAO_ADDR)?;
     MODERATOR.save(deps.storage, &moderator)?;
 
+    // Instantiate orderbook
     create_orderbook(deps, msg.quote_denom.clone(), msg.base_denom.clone())?;
 
     Ok(Response::new().add_attributes(vec![

--- a/contracts/sumtree-orderbook/src/msg.rs
+++ b/contracts/sumtree-orderbook/src/msg.rs
@@ -8,10 +8,6 @@ use osmosis_std::types::cosmos::base::v1beta1::Coin as ProtoCoin;
 pub struct InstantiateMsg {
     pub base_denom: String,
     pub quote_denom: String,
-    pub admin: Addr,
-    pub moderator: Addr,
-    pub maker_fee: Option<Decimal>,
-    pub maker_fee_recipient: Addr,
 }
 
 /// Message type for `execute` entry_point

--- a/contracts/sumtree-orderbook/src/orderbook.rs
+++ b/contracts/sumtree-orderbook/src/orderbook.rs
@@ -1,9 +1,11 @@
-use crate::constants::{MAX_TICK, MIN_TICK};
+use crate::constants::{
+    DEFAULT_MAKER_FEE, DEFAULT_MAKER_FEE_RECIPIENT, MAX_MAKER_FEE_PERCENTAGE, MAX_TICK, MIN_TICK,
+};
 use crate::error::ContractResult;
-use crate::state::ORDERBOOK;
+use crate::state::{MAKER_FEE, MAKER_FEE_RECIPIENT, ORDERBOOK};
 use crate::types::Orderbook;
 use crate::ContractError;
-use cosmwasm_std::{ensure, DepsMut};
+use cosmwasm_std::{ensure, Decimal256, DepsMut, Storage};
 
 pub fn create_orderbook(
     deps: DepsMut,
@@ -24,8 +26,40 @@ pub fn create_orderbook(
         );
     }
 
+    // Instantiate orderbook and write to state
     let book = Orderbook::new(quote_denom, base_denom, 0, MIN_TICK, MAX_TICK);
-
     ORDERBOOK.save(deps.storage, &book)?;
+
+    // Set maker fee
+    set_maker_fee(deps.storage, DEFAULT_MAKER_FEE)?;
+
+    // Set maker fee recipient
+    set_maker_fee_recipient(deps, DEFAULT_MAKER_FEE_RECIPIENT)?;
+
+    Ok(())
+}
+
+/// Sets the maker fee amount for the orderbook.
+pub fn set_maker_fee(
+    storage: &mut dyn Storage,
+    maker_fee: Decimal256,
+) -> ContractResult<Decimal256> {
+    ensure!(
+        maker_fee <= MAX_MAKER_FEE_PERCENTAGE,
+        ContractError::InvalidMakerFee {}
+    );
+    MAKER_FEE.save(storage, &maker_fee)?;
+
+    Ok(maker_fee)
+}
+
+/// Sets the recipient address for the maker fee for the orderbook.
+pub fn set_maker_fee_recipient(deps: DepsMut, maker_fee_recipient: &str) -> ContractResult<()> {
+    let addr = deps
+        .api
+        .addr_validate(maker_fee_recipient)
+        .map_err(|_| ContractError::InvalidMakerFeeRecipient)?;
+    MAKER_FEE_RECIPIENT.save(deps.storage, &addr)?;
+
     Ok(())
 }

--- a/contracts/sumtree-orderbook/src/tests/mod.rs
+++ b/contracts/sumtree-orderbook/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod mock_querier;
 pub mod test_auth;
 mod test_constants;
+pub mod test_instantiate;
 pub mod test_order;
 pub mod test_orderbook;
 pub mod test_query;

--- a/contracts/sumtree-orderbook/src/tests/test_auth.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_auth.rs
@@ -878,7 +878,7 @@ fn test_set_maker_fee() {
             name: "valid fee set by moderator",
             sender: current_moderator,
             fee: Decimal256::percent(1),
-            expected_error: None,
+            expected_error: Some(ContractError::Unauthorized {}),
         },
         SetMakerFeeTestCase {
             name: "valid fee set by admin",
@@ -975,10 +975,10 @@ fn test_set_maker_fee_recipient() {
             expected_error: None,
         },
         SetMakerFeeRecipientTestCase {
-            name: "valid set by moderator",
+            name: "invalid set by moderator",
             sender: current_moderator,
             recipient,
-            expected_error: None,
+            expected_error: Some(ContractError::Unauthorized {}),
         },
         SetMakerFeeRecipientTestCase {
             name: "invalid set by unauthorized user",

--- a/contracts/sumtree-orderbook/src/tests/test_instantiate.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_instantiate.rs
@@ -1,0 +1,67 @@
+use cosmwasm_std::{
+    coin,
+    testing::{mock_env, mock_info},
+};
+
+use super::{
+    mock_querier::mock_dependencies_custom,
+    test_constants::{BASE_DENOM, DEFAULT_SENDER, QUOTE_DENOM},
+};
+use crate::{contract::instantiate, msg::InstantiateMsg, ContractError};
+
+struct InstantiateTestCase {
+    name: &'static str,
+    msg: InstantiateMsg,
+    expected_error: Option<ContractError>,
+}
+
+#[test]
+fn test_instantiate() {
+    let test_cases = vec![
+        InstantiateTestCase {
+            name: "valid instantiate",
+            msg: InstantiateMsg {
+                quote_denom: QUOTE_DENOM.to_string(),
+                base_denom: BASE_DENOM.to_string(),
+            },
+            expected_error: None,
+        },
+        InstantiateTestCase {
+            name: "invalid instantiate",
+            msg: InstantiateMsg {
+                // Same denom for both quote and base
+                quote_denom: QUOTE_DENOM.to_string(),
+                base_denom: QUOTE_DENOM.to_string(),
+            },
+            expected_error: Some(ContractError::DuplicateDenoms {}),
+        },
+    ];
+
+    for test in test_cases {
+        // -- Test Setup --
+        let mut deps = mock_dependencies_custom();
+        let env = mock_env();
+        let info = mock_info(DEFAULT_SENDER, &[coin(100u128, BASE_DENOM)]);
+
+        // -- System under test --
+        let res = instantiate(deps.as_mut(), env, info, test.msg);
+
+        // -- Post Test Assertions --
+        if let Some(err) = test.expected_error {
+            assert_eq!(
+                res.unwrap_err(),
+                err,
+                "{}: did not receive expected error",
+                test.name
+            );
+            continue;
+        }
+
+        assert!(
+            res.is_ok(),
+            "{}: instantiate message unexpectedly failed; {}",
+            test.name,
+            res.unwrap_err()
+        );
+    }
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #185

## What is the purpose of the change
This PR wires up several hard-coded addresses into the orderbook contract. Specifically, it assigns the following:
* Admin: Osmosis governance address (`osmo10d07y265gmmuvt4z0w9aw880jnsr700jjeq4qp`)
* Moderator (freeze privileges): Circuit breaker subDAO (`osmo1peuxfjj66n2qt2v5jmqlvzz8neakjgduez7vttvemw58uug6546sr60ngl`)
* Maker fee recipient: module address that taker fees go to (`osmo1r9jc2234fljy93z80cevqjt3nmjycec8aj4cc6`)
* Maker fee: zero (can be updated by admin/governance)

## Testing and Verifying

While the base changes have been tested, the specific addresses need to be manually verified to ensure no mistakes were made.