### PR TITLE
[Sumtree]: Add denom to cancel limit return attributes

### DIFF
--- a/contracts/sumtree-orderbook/src/order.rs
+++ b/contracts/sumtree-orderbook/src/order.rs
@@ -251,14 +251,14 @@ pub fn claim_limit(
 
     let orderbook = ORDERBOOK.load(deps.storage)?;
     let order_denom = orderbook.get_expected_denom(&order.order_direction);
-    let received_denom = orderbook.get_opposite_denom(&order.order_direction);
+    let output_denom = orderbook.get_opposite_denom(&order.order_direction);
 
     let event = generate_claimed_order_event(
         info.sender,
         order,
         amount_claimed,
         order_denom,
-        received_denom,
+        output_denom,
     );
 
     Ok(Response::new()
@@ -298,13 +298,13 @@ pub fn batch_claim_limits(
         ) {
             Ok((amount_claimed, mut bank_msgs, order)) => {
                 let order_denom = orderbook.get_expected_denom(&order.order_direction);
-                let received_denom = orderbook.get_opposite_denom(&order.order_direction);
+                let output_denom = orderbook.get_opposite_denom(&order.order_direction);
                 let event = generate_claimed_order_event(
                     info.sender.clone(),
                     order,
                     amount_claimed,
                     order_denom,
-                    received_denom,
+                    output_denom,
                 );
                 responses.append(&mut bank_msgs);
                 events.push(event);
@@ -330,7 +330,7 @@ fn generate_claimed_order_event(
     order: LimitOrder,
     amount_claimed: Uint256,
     order_denom: String,
-    received_denom: String,
+    output_denom: String,
 ) -> Event {
     Event::new("limitClaimed").add_attributes(vec![
         ("sender", sender.as_str()),
@@ -343,7 +343,7 @@ fn generate_claimed_order_event(
         ("placed_quantity", &order.placed_quantity.to_string()),
         ("fully_claimed", &order.quantity.is_zero().to_string()),
         ("order_denom", &order_denom.to_string()),
-        ("received_denom", &received_denom.to_string()),
+        ("output_denom", &output_denom.to_string()),
     ])
 }
 

--- a/contracts/sumtree-orderbook/src/order.rs
+++ b/contracts/sumtree-orderbook/src/order.rs
@@ -191,7 +191,7 @@ pub fn cancel_limit(
     let refund_msg = SubMsg::reply_on_error(
         BankMsg::Send {
             to_address: order.owner.to_string(),
-            amount: vec![coin(order.quantity.u128(), expected_denom)],
+            amount: vec![coin(order.quantity.u128(), expected_denom.clone())],
         },
         REPLY_ID_REFUND,
     );
@@ -216,6 +216,7 @@ pub fn cancel_limit(
             ("quantity", &order.quantity.to_string()),
             ("order_direction", &order.order_direction.to_string()),
             ("initial_quantity", &order.placed_quantity.to_string()),
+            ("order_denom", &expected_denom.to_string()),
         ])
         .add_submessage(refund_msg))
 }

--- a/contracts/sumtree-orderbook/src/tests/test_order.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_order.rs
@@ -543,6 +543,13 @@ fn test_cancel_limit() {
             format_test_name(test.name)
         );
         assert_eq!(
+            response.attributes[7],
+            // Since this test does not cover partial fills, the remaining quantity is the same as the initial placed quantity
+            ("order_denom", refund_denom),
+            "{}",
+            format_test_name(test.name)
+        );
+        assert_eq!(
             response.messages.len(),
             1,
             "{}",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #183

## What is the purpose of the change

Minor addition to aid with indexing cancelled orders. Adds the cancelled order's denom to the return attributes of `CancelLimit`

## Testing and Verifying

Tests can be found in `test_order.rs`