### PR TITLE
fix: Tick pointer adjustments

### DIFF
--- a/contracts/sumtree-orderbook/src/msg.rs
+++ b/contracts/sumtree-orderbook/src/msg.rs
@@ -55,7 +55,7 @@ pub enum AuthExecuteMsg {
 
 /// Message type for `migrate` entry_point
 #[cw_serde]
-pub enum MigrateMsg {}
+pub struct MigrateMsg {}
 
 #[cw_serde]
 pub struct DenomsResponse {

--- a/contracts/sumtree-orderbook/src/order.rs
+++ b/contracts/sumtree-orderbook/src/order.rs
@@ -495,12 +495,6 @@ pub(crate) fn run_market_order_internal(
         let tick_price = tick_to_price(current_tick_id)?;
         last_tick_price = tick_price;
 
-        // Update current tick pointer as we visit ticks
-        match order.order_direction.opposite() {
-            OrderDirection::Ask => orderbook.next_ask_tick = current_tick_id,
-            OrderDirection::Bid => orderbook.next_bid_tick = current_tick_id,
-        }
-
         let output_quantity = amount_to_value(
             order.order_direction,
             order.quantity,
@@ -514,6 +508,12 @@ pub(crate) fn run_market_order_internal(
         if output_quantity.is_zero() {
             order.quantity = Uint128::zero();
             break;
+        }
+
+        // Update current tick pointer as we visit ticks that contribute to filling the order
+        match order.order_direction.opposite() {
+            OrderDirection::Ask => orderbook.next_ask_tick = current_tick_id,
+            OrderDirection::Bid => orderbook.next_bid_tick = current_tick_id,
         }
 
         let output_quantity_dec = Decimal256::from_ratio(output_quantity, Uint256::one());

--- a/contracts/sumtree-orderbook/src/order.rs
+++ b/contracts/sumtree-orderbook/src/order.rs
@@ -243,8 +243,8 @@ pub fn claim_limit(
 
     let (amount_claimed, bank_msgs, order) = claim_order(
         deps.storage,
-        info.sender.clone(),
         env.contract.address,
+        info.sender.clone(),
         tick_id,
         order_id,
     )?;

--- a/contracts/sumtree-orderbook/src/tests/test_order.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_order.rs
@@ -11,7 +11,7 @@ use crate::{
     },
 };
 use cosmwasm_std::{
-    coin, Addr, BankMsg, Coin, Empty, SubMsg, Uint128, Uint256,
+    coin, Addr, BankMsg, Coin, Empty, SubMsg, Uint128, Uint256
 };
 use cosmwasm_std::{
     testing::{mock_env, mock_info},
@@ -2758,7 +2758,7 @@ fn test_claim_order() {
         // Test Setup
         let mut deps = mock_dependencies_custom();
         let env = mock_env();
-        let info = mock_info(DEFAULT_SENDER, &[]);
+        let info = mock_info(test.sender.as_str(), &[]);
         create_orderbook(
             deps.as_mut(),
             QUOTE_DENOM.to_string(),
@@ -2774,10 +2774,10 @@ fn test_claim_order() {
         }
 
         // Claim designated order
-        let res = claim_order(
-            deps.as_mut().storage,
-            env.contract.address,
-            test.sender,
+        let res = claim_limit(
+            deps.as_mut(),
+            env,
+            info,
             test.tick_id,
             test.order_id,
         );
@@ -2791,23 +2791,24 @@ fn test_claim_order() {
 
         // Assert that the generated bank and bounty messages are as expected
         assert_eq!(
-            res.1[0],
+            res.messages[0],
             test.expected_bank_msg,
             "{}",
             format_test_name(test.name)
         );
+
         if let Some(expected_bounty_msg) = test.expected_bounty_msg {
             // Bounty message expected
-            assert_eq!((res.1).len(), 2, "{}", format_test_name(test.name));
+            assert_eq!((res.messages).len(), 2, "{}", format_test_name(test.name));
             assert_eq!(
-                res.1[1],
+                res.messages[1],
                 expected_bounty_msg,
                 "{}",
                 format_test_name(test.name)
             );
         } else {
             // No bounty message expected
-            assert_eq!((res.1).len(), 1, "{}", format_test_name(test.name));
+            assert_eq!((res.messages).len(), 1, "{}", format_test_name(test.name));
         }
 
         // Check order in state
@@ -3457,7 +3458,7 @@ fn test_claim_order_moving_tick() {
         // Test Setup
         let mut deps = mock_dependencies_custom();
         let env = mock_env();
-        let info = mock_info(DEFAULT_SENDER, &[]);
+        let info = mock_info(test.sender.as_str(), &[]);
         create_orderbook(
             deps.as_mut(),
             QUOTE_DENOM.to_string(),
@@ -3473,10 +3474,10 @@ fn test_claim_order_moving_tick() {
         }
 
         // Claim designated order
-        let res = claim_order(
-            deps.as_mut().storage,
-            env.contract.address,
-            test.sender,
+        let res = claim_limit(
+            deps.as_mut(),
+            env,
+            info,
             test.tick_id,
             test.order_id,
         );
@@ -3490,7 +3491,7 @@ fn test_claim_order_moving_tick() {
 
         // Assert that the generated bank message is as expected
         assert_eq!(
-            res.1[0],
+            res.messages[0],
             test.expected_output,
             "{}",
             format_test_name(test.name)

--- a/contracts/sumtree-orderbook/src/tests/test_order.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_order.rs
@@ -1024,6 +1024,16 @@ fn test_run_market_order_moving_tick() {
                     Decimal256::zero(),
                     None,
                 )),
+                // Place Ask on third tick to ensure tick does not move more than it should
+                OrderOperation::PlaceLimit(LimitOrder::new(
+                    2,
+                    0,
+                    OrderDirection::Ask,
+                    Addr::unchecked(info.sender.as_str()),
+                    Uint128::from(10u128),
+                    Decimal256::zero(),
+                    None,
+                )),
                 // Fill all limits on tick 0 and 50% of tick 1, leaving tick 0 empty and forcing positive movement
                 OrderOperation::RunMarket(MarketOrder::new(
                     Uint128::from(15u128),
@@ -1248,6 +1258,16 @@ fn test_run_market_order_moving_tick() {
                 // Place Bid on negative tick
                 OrderOperation::PlaceLimit(LimitOrder::new(
                     -1,
+                    0,
+                    OrderDirection::Bid,
+                    Addr::unchecked(info.sender.as_str()),
+                    Uint128::from(10u128),
+                    Decimal256::zero(),
+                    None,
+                )),
+                // Place extra Bid on negative tick to ensure tick does not move more than it should
+                OrderOperation::PlaceLimit(LimitOrder::new(
+                    -2,
                     0,
                     OrderDirection::Bid,
                     Addr::unchecked(info.sender.as_str()),

--- a/contracts/sumtree-orderbook/src/tests/test_utils.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_utils.rs
@@ -60,7 +60,7 @@ impl OrderOperation {
                         OrderDirection::Bid => QUOTE_DENOM,
                     },
                 )];
-                let info = mock_info(info.sender.as_str(), &coin_vec);
+                let info = mock_info(limit_order.owner.as_str(), &coin_vec);
                 place_limit(
                     &mut deps,
                     env,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change
Upon testing the contracts on testnet I discovered that the pointer for the next available tick for each direction was being incorrectly updated when a market order was run. This was due to the pointer being updated before the exit condition for if the order was filled causing a state where an order is fully filled on one tick, the next available tick is visited and the pointer is updated even though there is available liquidity on the previous tick.

These changes reorder this logic to only update the pointers **after** the exit condition has been checked.

A small change is also included to repair the `claim_limit` entry point providing an incorrect address (did not apply to batch claim) and unit tests were updated to help catch this condition.


## Testing and Verifying
Moving tick tests were updated to verify the tick pointer references in orderbook state. Claim limit tests were updated to use `claim_limit` instead of `claim_order` for better testing of the entrypoint.