### PR TITLE
[Sumtree]: Ticks By IDs Query

### DIFF
--- a/contracts/sumtree-orderbook/src/contract.rs
+++ b/contracts/sumtree-orderbook/src/contract.rs
@@ -148,6 +148,9 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
         }
         QueryMsg::Denoms {} => Ok(to_json_binary(&query::denoms(deps)?)?),
         QueryMsg::GetMakerFee {} => Ok(to_json_binary(&state::get_maker_fee(deps.storage)?)?),
+        QueryMsg::TickUnrealizedCancelsById { tick_ids } => Ok(to_json_binary(
+            &query::ticks_unrealized_cancels_by_id(deps, tick_ids)?,
+        )?),
 
         // -- Auth Queries --
         QueryMsg::Auth(msg) => Ok(to_json_binary(&auth::query(deps, msg)?)?),

--- a/contracts/sumtree-orderbook/src/contract.rs
+++ b/contracts/sumtree-orderbook/src/contract.rs
@@ -148,7 +148,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
         }
         QueryMsg::Denoms {} => Ok(to_json_binary(&query::denoms(deps)?)?),
         QueryMsg::GetMakerFee {} => Ok(to_json_binary(&state::get_maker_fee(deps.storage)?)?),
-        QueryMsg::TickUnrealizedCancelsById { tick_ids } => Ok(to_json_binary(
+        QueryMsg::GetUnrealizedCancels { tick_ids } => Ok(to_json_binary(
             &query::ticks_unrealized_cancels_by_id(deps, tick_ids)?,
         )?),
 

--- a/contracts/sumtree-orderbook/src/contract.rs
+++ b/contracts/sumtree-orderbook/src/contract.rs
@@ -143,6 +143,9 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
         } => Ok(to_json_binary(&query::orders_by_owner(
             deps, owner, start_from, end_at, limit,
         )?)?),
+        QueryMsg::TicksById { tick_ids } => {
+            Ok(to_json_binary(&query::ticks_by_id(deps, tick_ids)?)?)
+        }
         QueryMsg::Denoms {} => Ok(to_json_binary(&query::denoms(deps)?)?),
         QueryMsg::GetMakerFee {} => Ok(to_json_binary(&state::get_maker_fee(deps.storage)?)?),
 

--- a/contracts/sumtree-orderbook/src/msg.rs
+++ b/contracts/sumtree-orderbook/src/msg.rs
@@ -127,8 +127,8 @@ pub enum QueryMsg {
     #[returns(TicksResponse)]
     TicksById { tick_ids: Vec<i64> },
 
-    #[returns(TickUnrealizedCancelsByIdResponse)]
-    TickUnrealizedCancelsById { tick_ids: Vec<i64> },
+    #[returns(GetUnrealizedCancelsResponse)]
+    GetUnrealizedCancels { tick_ids: Vec<i64> },
 }
 
 #[cw_serde]
@@ -182,7 +182,7 @@ pub struct TicksResponse {
 }
 
 #[cw_serde]
-pub struct TickUnrealizedCancelsState {
+pub struct UnrealizedCancels {
     pub ask_unrealized_cancels: Decimal256,
     pub bid_unrealized_cancels: Decimal256,
 }
@@ -190,11 +190,11 @@ pub struct TickUnrealizedCancelsState {
 #[cw_serde]
 pub struct TickUnrealizedCancels {
     pub tick_id: i64,
-    pub unrealized_cancels: TickUnrealizedCancelsState,
+    pub unrealized_cancels: UnrealizedCancels,
 }
 
 #[cw_serde]
-pub struct TickUnrealizedCancelsByIdResponse {
+pub struct GetUnrealizedCancelsResponse {
     pub ticks: Vec<TickUnrealizedCancels>,
 }
 

--- a/contracts/sumtree-orderbook/src/msg.rs
+++ b/contracts/sumtree-orderbook/src/msg.rs
@@ -97,6 +97,7 @@ pub enum QueryMsg {
         /// The limit for amount of items to return
         limit: Option<usize>,
     },
+
     #[returns(MakerFee)]
     GetMakerFee {},
 
@@ -104,6 +105,7 @@ pub enum QueryMsg {
     #[returns(Option<Addr>)]
     Auth(AuthQueryMsg),
 
+    // -- Contract Queries --
     #[returns(bool)]
     IsActive {},
 
@@ -121,6 +123,9 @@ pub enum QueryMsg {
 
     #[returns(DenomsResponse)]
     Denoms {},
+
+    #[returns(TicksByIdResponse)]
+    TicksById { tick_ids: Vec<i64> },
 }
 
 #[cw_serde]
@@ -163,13 +168,25 @@ pub struct MakerFee {
 }
 
 #[cw_serde]
+pub struct TickRealizedEffectiveTotalAmountSwapped {
+    pub ask_etas: Decimal256,
+    pub bid_etas: Decimal256,
+}
+
+#[cw_serde]
 pub struct TickIdAndState {
     pub tick_id: i64,
     pub tick_state: TickState,
+    pub realized_etas: TickRealizedEffectiveTotalAmountSwapped,
 }
 
 #[cw_serde]
 pub struct AllTicksResponse {
+    pub ticks: Vec<TickIdAndState>,
+}
+
+#[cw_serde]
+pub struct TicksByIdResponse {
     pub ticks: Vec<TickIdAndState>,
 }
 

--- a/contracts/sumtree-orderbook/src/msg.rs
+++ b/contracts/sumtree-orderbook/src/msg.rs
@@ -88,7 +88,7 @@ pub enum QueryMsg {
     GetSwapFee {},
 
     // -- SQS Queries --
-    #[returns(AllTicksResponse)]
+    #[returns(TicksResponse)]
     AllTicks {
         /// The tick id to start after for pagination (inclusive)
         start_from: Option<i64>,
@@ -124,8 +124,11 @@ pub enum QueryMsg {
     #[returns(DenomsResponse)]
     Denoms {},
 
-    #[returns(TicksByIdResponse)]
+    #[returns(TicksResponse)]
     TicksById { tick_ids: Vec<i64> },
+
+    #[returns(TickUnrealizedCancelsByIdResponse)]
+    TickUnrealizedCancelsById { tick_ids: Vec<i64> },
 }
 
 #[cw_serde]
@@ -168,26 +171,31 @@ pub struct MakerFee {
 }
 
 #[cw_serde]
-pub struct TickRealizedEffectiveTotalAmountSwapped {
-    pub ask_etas: Decimal256,
-    pub bid_etas: Decimal256,
-}
-
-#[cw_serde]
 pub struct TickIdAndState {
     pub tick_id: i64,
     pub tick_state: TickState,
-    pub synced_etas: TickRealizedEffectiveTotalAmountSwapped,
 }
 
 #[cw_serde]
-pub struct AllTicksResponse {
+pub struct TicksResponse {
     pub ticks: Vec<TickIdAndState>,
 }
 
 #[cw_serde]
-pub struct TicksByIdResponse {
-    pub ticks: Vec<TickIdAndState>,
+pub struct TickUnrealizedCancelsState {
+    pub ask_unrealized_cancels: Decimal256,
+    pub bid_unrealized_cancels: Decimal256,
+}
+
+#[cw_serde]
+pub struct TickUnrealizedCancels {
+    pub tick_id: i64,
+    pub unrealized_cancels: TickUnrealizedCancelsState,
+}
+
+#[cw_serde]
+pub struct TickUnrealizedCancelsByIdResponse {
+    pub ticks: Vec<TickUnrealizedCancels>,
 }
 
 #[cw_serde]

--- a/contracts/sumtree-orderbook/src/msg.rs
+++ b/contracts/sumtree-orderbook/src/msg.rs
@@ -177,7 +177,7 @@ pub struct TickRealizedEffectiveTotalAmountSwapped {
 pub struct TickIdAndState {
     pub tick_id: i64,
     pub tick_state: TickState,
-    pub realized_etas: TickRealizedEffectiveTotalAmountSwapped,
+    pub synced_etas: TickRealizedEffectiveTotalAmountSwapped,
 }
 
 #[cw_serde]

--- a/contracts/sumtree-orderbook/src/query.rs
+++ b/contracts/sumtree-orderbook/src/query.rs
@@ -218,20 +218,17 @@ pub(crate) fn denoms(deps: Deps) -> ContractResult<DenomsResponse> {
 }
 
 pub(crate) fn ticks_by_id(deps: Deps, tick_ids: Vec<i64>) -> ContractResult<TicksResponse> {
-    let ticks = tick_ids
-        .iter()
-        .map(|tick_id| {
-            let tick_state = TICK_STATE
-                .load(deps.storage, *tick_id)
-                .map_err(|_| ContractError::InvalidTickId { tick_id: *tick_id })
-                .unwrap();
+    let mut ticks: Vec<TickIdAndState> = vec![];
+    for tick_id in tick_ids {
+        let Some(tick_state) = TICK_STATE.may_load(deps.storage, tick_id)? else {
+            return Err(ContractError::InvalidTickId { tick_id });
+        };
 
-            TickIdAndState {
-                tick_id: *tick_id,
-                tick_state,
-            }
-        })
-        .collect();
+        ticks.push(TickIdAndState {
+            tick_id,
+            tick_state,
+        });
+    }
 
     Ok(TicksResponse { ticks })
 }

--- a/contracts/sumtree-orderbook/src/query.rs
+++ b/contracts/sumtree-orderbook/src/query.rs
@@ -133,7 +133,7 @@ pub(crate) fn total_pool_liquidity(deps: Deps) -> ContractResult<GetTotalPoolLiq
     })
 }
 
-fn get_realized_etas(
+fn get_synced_etas(
     deps: Deps,
     tick_state: TickState,
     tick_id: i64,
@@ -184,11 +184,11 @@ pub(crate) fn all_ticks(
             .take(limit)
             .map(|maybe_tick| {
                 let (tick_id, tick_state) = maybe_tick.unwrap();
-                let realized_etas = get_realized_etas(deps, tick_state.clone(), tick_id).unwrap();
+                let synced_etas = get_synced_etas(deps, tick_state.clone(), tick_id).unwrap();
                 TickIdAndState {
                     tick_id,
                     tick_state,
-                    realized_etas,
+                    synced_etas,
                 }
             })
             .collect()
@@ -196,11 +196,11 @@ pub(crate) fn all_ticks(
         all_ticks
             .map(|maybe_tick| {
                 let (tick_id, tick_state) = maybe_tick.unwrap();
-                let realized_etas = get_realized_etas(deps, tick_state.clone(), tick_id).unwrap();
+                let synced_etas = get_synced_etas(deps, tick_state.clone(), tick_id).unwrap();
                 TickIdAndState {
                     tick_id,
                     tick_state,
-                    realized_etas,
+                    synced_etas,
                 }
             })
             .collect()
@@ -258,12 +258,12 @@ pub(crate) fn ticks_by_id(deps: Deps, tick_ids: Vec<i64>) -> ContractResult<Tick
                 .load(deps.storage, *tick_id)
                 .map_err(|_| ContractError::InvalidTickId { tick_id: *tick_id })
                 .unwrap();
-            let realized_etas = get_realized_etas(deps, tick_state.clone(), *tick_id).unwrap();
+            let synced_etas = get_synced_etas(deps, tick_state.clone(), *tick_id).unwrap();
 
             TickIdAndState {
                 tick_id: *tick_id,
                 tick_state,
-                realized_etas,
+                synced_etas,
             }
         })
         .collect();

--- a/contracts/sumtree-orderbook/src/query.rs
+++ b/contracts/sumtree-orderbook/src/query.rs
@@ -8,8 +8,8 @@ use crate::{
     error::ContractResult,
     msg::{
         CalcOutAmtGivenInResponse, DenomsResponse, GetSwapFeeResponse,
-        GetTotalPoolLiquidityResponse, SpotPriceResponse, TickIdAndState, TickUnrealizedCancels,
-        TickUnrealizedCancelsByIdResponse, TickUnrealizedCancelsState, TicksResponse,
+        GetTotalPoolLiquidityResponse, GetUnrealizedCancelsResponse, SpotPriceResponse,
+        TickIdAndState, TickUnrealizedCancels, TicksResponse, UnrealizedCancels,
     },
     order,
     state::{get_directional_liquidity, get_orders_by_owner, IS_ACTIVE, ORDERBOOK, TICK_STATE},
@@ -238,7 +238,7 @@ fn get_unrealized_cancels(
     deps: Deps,
     tick_state: TickState,
     tick_id: i64,
-) -> ContractResult<TickUnrealizedCancelsState> {
+) -> ContractResult<UnrealizedCancels> {
     let mut cancels: (Decimal256, Decimal256) = (Decimal256::zero(), Decimal256::zero());
     for direction in [OrderDirection::Ask, OrderDirection::Bid] {
         let tick_values = tick_state.get_values(direction);
@@ -264,7 +264,7 @@ fn get_unrealized_cancels(
 
     let (ask_unrealized_cancels, bid_unrealized_cancels) = cancels;
 
-    Ok(TickUnrealizedCancelsState {
+    Ok(UnrealizedCancels {
         ask_unrealized_cancels,
         bid_unrealized_cancels,
     })
@@ -274,7 +274,7 @@ fn get_unrealized_cancels(
 pub(crate) fn ticks_unrealized_cancels_by_id(
     deps: Deps,
     tick_ids: Vec<i64>,
-) -> ContractResult<TickUnrealizedCancelsByIdResponse> {
+) -> ContractResult<GetUnrealizedCancelsResponse> {
     let mut ticks: Vec<TickUnrealizedCancels> = vec![];
     for tick_id in tick_ids {
         let Some(tick_state) = TICK_STATE.may_load(deps.storage, tick_id)? else {
@@ -287,5 +287,5 @@ pub(crate) fn ticks_unrealized_cancels_by_id(
         });
     }
 
-    Ok(TickUnrealizedCancelsByIdResponse { ticks })
+    Ok(GetUnrealizedCancelsResponse { ticks })
 }

--- a/contracts/sumtree-orderbook/src/tests/test_query.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_query.rs
@@ -8,7 +8,7 @@ use crate::{
     constants::{EXPECTED_SWAP_FEE, MAX_TICK, MIN_TICK},
     orderbook::create_orderbook,
     query,
-    state::{IS_ACTIVE, TICK_STATE},
+    state::IS_ACTIVE,
     tests::mock_querier::mock_dependencies_custom,
     types::{coin_u256, Coin256, LimitOrder, MarketOrder, OrderDirection, TickState, TickValues},
     ContractError,

--- a/contracts/sumtree-orderbook/src/tests/test_query.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_query.rs
@@ -1802,11 +1802,8 @@ fn test_tick_unrealized_cancels_by_id() {
             .ticks
             .iter()
             .flat_map(|t| {
-                let tick_state = TICK_STATE.load(deps.as_ref().storage, t.tick_id).unwrap();
-                let bid_cancel_diff = t.unrealized_cancels.bid_unrealized_cancels
-                    - tick_state.bid_values.cumulative_realized_cancels;
-                let ask_cancel_diff = t.unrealized_cancels.ask_unrealized_cancels
-                    - tick_state.ask_values.cumulative_realized_cancels;
+                let bid_cancel_diff = t.unrealized_cancels.bid_unrealized_cancels;
+                let ask_cancel_diff = t.unrealized_cancels.ask_unrealized_cancels;
                 vec![
                     (t.tick_id, (OrderDirection::Bid, bid_cancel_diff)),
                     (t.tick_id, (OrderDirection::Ask, ask_cancel_diff)),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change
These changes add two new features:
- `TicksById` query that can fetch tick info given an array of tick IDs
- `GetUnrealizedCancels` query that fetches the total value of unrealized cancels that will be realized in the next sync

The reason for these changes is for UX, currently the frontend cannot know how much of a tick is filled until it is synced. These changes allow the frontend to actively know how much ETAS there is on a tick.

## Testing and Verifying
Added two new tests for the new queries. These can be run using:

```
cargo unit-test test_query
```