### PR TITLE
[Sumtree]: Tick Sync Pre Cancellation

### DIFF
--- a/contracts/sumtree-orderbook/src/order.rs
+++ b/contracts/sumtree-orderbook/src/order.rs
@@ -155,6 +155,19 @@ pub fn cancel_limit(
     // Ensure the sender is the order owner
     ensure_eq!(info.sender, order.owner, ContractError::Unauthorized {});
 
+    // Sync tick before checking if order is filled
+    let tick_state = TICK_STATE.load(deps.storage, tick_id).unwrap_or_default();
+    sync_tick(
+        deps.storage,
+        tick_id,
+        tick_state
+            .get_values(OrderDirection::Bid)
+            .effective_total_amount_swapped,
+        tick_state
+            .get_values(OrderDirection::Ask)
+            .effective_total_amount_swapped,
+    )?;
+
     // Ensure the order has not been filled.
     let tick_state = TICK_STATE.load(deps.storage, tick_id).unwrap_or_default();
     let tick_values = tick_state.get_values(order.order_direction);

--- a/contracts/sumtree-orderbook/src/tests/test_order.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_order.rs
@@ -2773,6 +2773,20 @@ fn test_claim_order() {
                 .unwrap();
         }
 
+        // Ensure that a claimable order cannot be cancelled
+        if test.expected_error.is_none() {
+            let mut info_with_sender = info.clone();
+            info_with_sender.sender = sender.clone();
+            let res = cancel_limit(
+                deps.as_mut(),
+                env.clone(),
+                info_with_sender.clone(),
+                test.tick_id,
+                test.order_id,
+            );
+            assert_eq!(res, Err(ContractError::CancelFilledOrder));
+        }
+
         // Claim designated order
         let res = claim_limit(
             deps.as_mut(),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change
A case arose during fuzz testing that pointed out that the current implementation for cancelling an order allowed an order to be cancelled when it had been filled. The issue is that the tick was not being synced before ensuring that the order had not been filled (even partially). These changes add syncing the tick before ensuring the order is not filled.

## Testing and Verifying
N/A