### PR TITLE
[Sumtree]: Prefix Sum Resync Condition

### DIFF
--- a/contracts/sumtree-orderbook/src/error.rs
+++ b/contracts/sumtree-orderbook/src/error.rs
@@ -88,6 +88,9 @@ pub enum ContractError {
     #[error("Invalid tick state: syncing tick pushed ETAS past CTT")]
     InvalidTickSync,
 
+    #[error("Invalid prefix sum: {error:?}")]
+    InvalidPrefixSum { error: Option<String> },
+
     #[error("Zero Claim: Nothing to be claimed yet")]
     ZeroClaim,
 

--- a/contracts/sumtree-orderbook/src/query.rs
+++ b/contracts/sumtree-orderbook/src/query.rs
@@ -8,8 +8,8 @@ use crate::{
     error::ContractResult,
     msg::{
         CalcOutAmtGivenInResponse, DenomsResponse, GetSwapFeeResponse,
-        GetTotalPoolLiquidityResponse, GetUnrealizedCancelsResponse, OrdersResponse, SpotPriceResponse,
-        TickIdAndState, TickUnrealizedCancels, TicksResponse, UnrealizedCancels,
+        GetTotalPoolLiquidityResponse, GetUnrealizedCancelsResponse, OrdersResponse,
+        SpotPriceResponse, TickIdAndState, TickUnrealizedCancels, TicksResponse, UnrealizedCancels,
     },
     order,
     state::{
@@ -252,6 +252,7 @@ fn get_unrealized_cancels(
                 deps.storage,
                 root_node,
                 tick_values.effective_total_amount_swapped,
+                tick_values.cumulative_realized_cancels,
             )?;
 
             total_realized_cancels.saturating_sub(tick_values.cumulative_realized_cancels)

--- a/contracts/sumtree-orderbook/src/sumtree/test/test_fuzz.rs
+++ b/contracts/sumtree-orderbook/src/sumtree/test/test_fuzz.rs
@@ -74,9 +74,13 @@ fn test_fuzz_insert() {
             assert_sumtree_invariants(deps.as_ref(), &tree, &test_name);
 
             // Assert prefix sum correctness
-            let prefix_sum =
-                get_prefix_sum(deps.as_ref().storage, tree, target_etas, Decimal256::zero())
-                    .unwrap();
+            let prefix_sum = get_prefix_sum(
+                deps.as_ref().storage,
+                tree.clone(),
+                target_etas,
+                tree.get_value(),
+            )
+            .unwrap();
             assert_eq!(
                 expected_prefix_sum, prefix_sum,
                 "{test_name}: Expected prefix sum {expected_prefix_sum}, got {prefix_sum}. Target ETAS: {target_etas}",

--- a/contracts/sumtree-orderbook/src/sumtree/test/test_fuzz.rs
+++ b/contracts/sumtree-orderbook/src/sumtree/test/test_fuzz.rs
@@ -74,7 +74,9 @@ fn test_fuzz_insert() {
             assert_sumtree_invariants(deps.as_ref(), &tree, &test_name);
 
             // Assert prefix sum correctness
-            let prefix_sum = get_prefix_sum(deps.as_ref().storage, tree, target_etas).unwrap();
+            let prefix_sum =
+                get_prefix_sum(deps.as_ref().storage, tree, target_etas, Decimal256::zero())
+                    .unwrap();
             assert_eq!(
                 expected_prefix_sum, prefix_sum,
                 "{test_name}: Expected prefix sum {expected_prefix_sum}, got {prefix_sum}. Target ETAS: {target_etas}",

--- a/contracts/sumtree-orderbook/src/sumtree/test/test_node.rs
+++ b/contracts/sumtree-orderbook/src/sumtree/test/test_node.rs
@@ -2751,8 +2751,9 @@ fn test_node_insert_large_quantity() {
     // Ensure prefix sum functions correctly
     let root_node = get_root_node(deps.as_mut().storage,  tick_id, direction).unwrap();
 
+    // Use root node value as previous sum to use explicit prefix sum calculation with no overlaps
     let prefix_sum =
-        get_prefix_sum(deps.as_mut().storage, root_node, target_etas, Decimal256::zero())
+        get_prefix_sum(deps.as_mut().storage, root_node.clone(), target_etas, root_node.get_value())
             .unwrap();
     assert_eq!(expected_prefix_sum, prefix_sum);
 }

--- a/contracts/sumtree-orderbook/src/sumtree/test/test_node.rs
+++ b/contracts/sumtree-orderbook/src/sumtree/test/test_node.rs
@@ -2751,7 +2751,9 @@ fn test_node_insert_large_quantity() {
     // Ensure prefix sum functions correctly
     let root_node = get_root_node(deps.as_mut().storage,  tick_id, direction).unwrap();
 
-    let prefix_sum = get_prefix_sum(deps.as_mut().storage, root_node, target_etas).unwrap();
+    let prefix_sum =
+        get_prefix_sum(deps.as_mut().storage, root_node, target_etas, Decimal256::zero())
+            .unwrap();
     assert_eq!(expected_prefix_sum, prefix_sum);
 }
 

--- a/contracts/sumtree-orderbook/src/sumtree/test/test_tree.rs
+++ b/contracts/sumtree-orderbook/src/sumtree/test/test_tree.rs
@@ -183,7 +183,13 @@ fn test_get_prefix_sum_valid() {
         assert_internal_values(test.name, deps.as_ref(), internals, true);
 
         // System under test: get prefix sum
-        let prefix_sum = get_prefix_sum(deps.as_ref().storage, tree, test.target_etas).unwrap();
+        let prefix_sum = get_prefix_sum(
+            deps.as_ref().storage,
+            tree,
+            test.target_etas,
+            Decimal256::zero(),
+        )
+        .unwrap();
 
         // Assert that the correct value was returned
         assert_eq!(

--- a/contracts/sumtree-orderbook/src/sumtree/test/test_tree.rs
+++ b/contracts/sumtree-orderbook/src/sumtree/test/test_tree.rs
@@ -9,6 +9,7 @@ struct TestPrefixSumCase {
     name: &'static str,
     nodes: Vec<NodeType>,
     target_etas: Decimal256,
+    prev_sum: Decimal256,
     expected_sum: Decimal256,
 }
 
@@ -21,7 +22,7 @@ fn test_get_prefix_sum_valid() {
             name: "Single node, target ETAS equal to node ETAS",
             nodes: vec![NodeType::leaf_uint256(10u128, 5u128)],
             target_etas: Decimal256::from_ratio(10u128, 1u128),
-
+            prev_sum: Decimal256::zero(),
             // We expect the full value of the node because the prefix
             // sum is intended to return "all nodes that overlap with
             // the target ETAS".
@@ -34,14 +35,14 @@ fn test_get_prefix_sum_valid() {
             name: "Single node, target ETAS below node range",
             nodes: vec![NodeType::leaf_uint256(50u128, 20u128)],
             target_etas: Decimal256::from_ratio(25u128, 1u128),
-
+            prev_sum: Decimal256::zero(),
             expected_sum: Decimal256::zero(),
         },
         TestPrefixSumCase {
             name: "Single node, target ETAS above node range",
             nodes: vec![NodeType::leaf_uint256(10u128, 10u128)],
             target_etas: Decimal256::from_ratio(30u128, 1u128),
-
+            prev_sum: Decimal256::zero(),
             expected_sum: Decimal256::from_ratio(10u128, 1u128),
         },
         TestPrefixSumCase {
@@ -49,10 +50,10 @@ fn test_get_prefix_sum_valid() {
             nodes: vec![
                 NodeType::leaf_uint256(5u128, 10u128),
                 NodeType::leaf_uint256(15u128, 20u128),
-                NodeType::leaf_uint256(35u128, 30u128),
+                NodeType::leaf_uint256(45u128, 30u128),
             ],
             target_etas: Decimal256::from_ratio(20u128, 1u128),
-
+            prev_sum: Decimal256::from_ratio(10u128, 1u128),
             expected_sum: Decimal256::from_ratio(30u128, 1u128),
         },
         TestPrefixSumCase {
@@ -62,7 +63,7 @@ fn test_get_prefix_sum_valid() {
                 NodeType::leaf_uint256(5u128, 12u128),
             ],
             target_etas: Decimal256::from_ratio(5u128, 1u128),
-
+            prev_sum: Decimal256::zero(),
             expected_sum: Decimal256::from_ratio(15u128, 1u128),
         },
         TestPrefixSumCase {
@@ -73,7 +74,7 @@ fn test_get_prefix_sum_valid() {
                 NodeType::leaf_uint256(40u128, 30u128),
             ],
             target_etas: Decimal256::from_ratio(5u128, 1u128),
-
+            prev_sum: Decimal256::zero(),
             expected_sum: Decimal256::zero(),
         },
         TestPrefixSumCase {
@@ -84,40 +85,40 @@ fn test_get_prefix_sum_valid() {
                 NodeType::leaf_uint256(40u128, 30u128),
             ],
             target_etas: Decimal256::from_ratio(45u128, 1u128),
-
+            prev_sum: Decimal256::zero(),
             expected_sum: Decimal256::from_ratio(60u128, 1u128), // Sum of all nodes
         },
         TestPrefixSumCase {
             name: "Nodes inserted in reverse order",
             nodes: vec![
-                NodeType::leaf_uint256(30u128, 10u128),
+                NodeType::leaf_uint256(40u128, 10u128),
                 NodeType::leaf_uint256(20u128, 5u128),
                 NodeType::leaf_uint256(10u128, 5u128),
             ],
             target_etas: Decimal256::from_ratio(25u128, 1u128),
-
+            prev_sum: Decimal256::zero(),
             expected_sum: Decimal256::from_ratio(10u128, 1u128),
         },
         TestPrefixSumCase {
             name: "Nodes inserted in shuffled order",
             nodes: vec![
-                NodeType::leaf_uint256(30u128, 10u128),
+                NodeType::leaf_uint256(40u128, 10u128),
                 NodeType::leaf_uint256(10u128, 5u128),
                 NodeType::leaf_uint256(20u128, 5u128),
             ],
             target_etas: Decimal256::from_ratio(25u128, 1u128),
-
+            prev_sum: Decimal256::zero(),
             expected_sum: Decimal256::from_ratio(10u128, 1u128),
         },
         TestPrefixSumCase {
             name: "Nodes inserted in shuffled order, target ETAS at node lower bound",
             nodes: vec![
-                NodeType::leaf_uint256(30u128, 11u128),
+                NodeType::leaf_uint256(35u128, 11u128),
                 NodeType::leaf_uint256(10u128, 7u128),
                 NodeType::leaf_uint256(20u128, 5u128),
             ],
             target_etas: Decimal256::from_ratio(20u128, 1u128),
-
+            prev_sum: Decimal256::zero(),
             // We expect the sum of the 2nd and 3rd nodes, so 7 + 5
             expected_sum: Decimal256::from_ratio(12u128, 1u128),
         },
@@ -129,7 +130,7 @@ fn test_get_prefix_sum_valid() {
                 NodeType::leaf_uint256(100u128, 30u128),
             ],
             target_etas: Decimal256::from_ratio(75u128, 1u128),
-
+            prev_sum: Decimal256::from_ratio(70u128, 1u128),
             expected_sum: Decimal256::from_ratio(30u128, 1u128),
         },
         TestPrefixSumCase {
@@ -139,9 +140,9 @@ fn test_get_prefix_sum_valid() {
                 NodeType::leaf_uint256(20u128, 10u128),
                 NodeType::leaf_uint256(30u128, 10u128),
             ],
-            target_etas: Decimal256::from_ratio(25u128, 1u128),
-
-            expected_sum: Decimal256::from_ratio(20u128, 1u128),
+            target_etas: Decimal256::from_ratio(10u128, 1u128),
+            prev_sum: Decimal256::zero(),
+            expected_sum: Decimal256::from_ratio(30u128, 1u128),
         },
         TestPrefixSumCase {
             name: "Complex case with many nodes (shuffled, adjacent, spaced out)",
@@ -160,7 +161,8 @@ fn test_get_prefix_sum_valid() {
             ],
             // Target includes everything except the last two nodes
             target_etas: Decimal256::from_ratio(305u128, 1u128),
-
+            // Previous sum at 4th last node max to prevent final two nodes being synced after previous nodes being synced
+            prev_sum: Decimal256::from_ratio(300u128, 1u128),
             // Sum of all nodes except the last two:
             // 5 + 19 + 4 + 10 + 9 + 20 + 50 + 40 + 29 = 186
             expected_sum: Decimal256::from_ratio(186u128, 1u128),
@@ -183,13 +185,8 @@ fn test_get_prefix_sum_valid() {
         assert_internal_values(test.name, deps.as_ref(), internals, true);
 
         // System under test: get prefix sum
-        let prefix_sum = get_prefix_sum(
-            deps.as_ref().storage,
-            tree,
-            test.target_etas,
-            Decimal256::zero(),
-        )
-        .unwrap();
+        let prefix_sum =
+            get_prefix_sum(deps.as_ref().storage, tree, test.target_etas, test.prev_sum).unwrap();
 
         // Assert that the correct value was returned
         assert_eq!(

--- a/contracts/sumtree-orderbook/src/sumtree/tree.rs
+++ b/contracts/sumtree-orderbook/src/sumtree/tree.rs
@@ -136,6 +136,11 @@ fn prefix_sum_walk(
         // amount corresponds exactly to `unrealized_from_left`.
         let unrealized_from_left = left_child.get_value().saturating_sub(diff_at_node);
         // Calculate the new ETAS after realizing what is unrealized from the left node
+        //
+        // Instead of doing this manually (and expensively) by triggering a resync, we simply add `unrealized_from_left`
+        // to the running target ETAS value. This is functionally equivalent to simulating realizing the
+        // remainder of the left child. As a sanity check, if it was already realized, then `unrealized_from_left`
+        // would be zero and the target ETAS would remain unchanged.
         let new_etas = target_etas.checked_add(unrealized_from_left)?;
 
         // if the new ETAS is greater than or equal to the right child's min range, we can walk right

--- a/contracts/sumtree-orderbook/src/sumtree/tree.rs
+++ b/contracts/sumtree-orderbook/src/sumtree/tree.rs
@@ -103,7 +103,7 @@ fn prefix_sum_walk(
     // in which cancels are realized and can simply "batch realize" all of them.
     //
     // This case is characterized by when the amount filled on the current tick + the unrealized cancellations in the
-    //  left child of a node pushes ETAS into the range of the right child node (i.e. where the next order in line, after
+    // left child of a node pushes ETAS into the range of the right child node (i.e. where the next order in line, after
     // the sync is complete, is guaranteed to be another cancel). In this case, we count the left child as fully realized
     // and roll the newly realized portion into the target ETAS. This is functionally equivalent to batching multiple
     // syncs into one.
@@ -113,15 +113,15 @@ fn prefix_sum_walk(
 
         // `sum_at_node` corresponds to everything to the left and in the current node.
         // We don't know which component of the current node, if any, will be included, so we remove the whole thing.
-        // 
+        //
         // Sanity check: for the root node, this will be 0, since the "current node" is the root and includes the whole
         // tree (so when it is removed, there is nothing left)
         let sum_at_node = current_sum.checked_sub(node.get_value())?;
         // Calculate the amount of cumulative realized cancellations *below the current node*  at the end of the
         // previous sync.
         //
-        // Recall that `prev_sum` is the cumulative *global* amount that was realized at the end of the previous sync. 
-        // 
+        // Recall that `prev_sum` is the cumulative *global* amount that was realized at the end of the previous sync.
+        //
         // Concretely, if this value is ever nonzero for a node, the amount corresponds exactly to the amount realized
         // below the node at the end of the previous sync. In all other cases, it will snap to zero due to the saturating sub.
         let diff_at_node = prev_sum.saturating_sub(sum_at_node);
@@ -131,7 +131,7 @@ fn prefix_sum_walk(
         // If the left child is fully realized then the subtraction here will either be zero (if none of the right child is
         // realized) or negative (if some of the right child is realized), since `diff_at_node` = amount realized below left
         // and below right children. Saturating sub will ensure both of these cases snap to zero.
-        // 
+        //
         // Thus, if this value is ever nonzero, it means that the left child had some unrealized cancels in it, and the
         // amount corresponds exactly to `unrealized_from_left`.
         let unrealized_from_left = left_child.get_value().saturating_sub(diff_at_node);

--- a/contracts/sumtree-orderbook/src/sumtree/tree.rs
+++ b/contracts/sumtree-orderbook/src/sumtree/tree.rs
@@ -117,7 +117,13 @@ fn prefix_sum_walk(
         // Sanity check: for the root node, this will be 0, since the "current node" is the root and includes the whole
         // tree (so when it is removed, there is nothing left)
         let sum_at_node = current_sum.checked_sub(node.get_value())?;
-        // Calculate how much of the node has been realized in a previous sync
+        // Calculate the amount of cumulative realized cancellations *below the current node*  at the end of the
+        // previous sync.
+        //
+        // Recall that `prev_sum` is the cumulative *global* amount that was realized at the end of the previous sync. 
+        // 
+        // Concretely, if this value is ever nonzero for a node, the amount corresponds exactly to the amount realized
+        // below the node at the end of the previous sync. In all other cases, it will snap to zero due to the saturating sub.
         let diff_at_node = prev_sum.saturating_sub(sum_at_node);
         // Calculate how much of the left node is unrealized
         let unrealized_from_left = left_child.get_value().saturating_sub(diff_at_node);

--- a/contracts/sumtree-orderbook/src/sumtree/tree.rs
+++ b/contracts/sumtree-orderbook/src/sumtree/tree.rs
@@ -90,12 +90,12 @@ fn prefix_sum_walk(
         return Ok(current_sum);
     }
 
-    // --- Attempt walk left ---
-
     // We fetch both children here since we need to access both regardless of
     // whether we walk left or right.
     let left_child = node.get_left(storage)?;
     let right_child = node.get_right(storage)?;
+
+    // -- Resync Condition --
 
     // To prevent requiring a resync there needs to be a condition that covers the case that
     // when realizing the left node the new ETAS is enough to realize the right node (to some extent)
@@ -121,6 +121,8 @@ fn prefix_sum_walk(
             return prefix_sum_walk(storage, &right_child, current_sum, new_etas, prev_sum);
         }
     }
+
+    // --- Attempt walk left ---
 
     // If the left child exists, we run the following logic:
     // * If target ETAS < left child's lower bound, exit early with zero

--- a/contracts/sumtree-orderbook/src/sumtree/tree.rs
+++ b/contracts/sumtree-orderbook/src/sumtree/tree.rs
@@ -111,7 +111,11 @@ fn prefix_sum_walk(
         let left_child = left_child.clone().unwrap();
         let right_child = right_child.clone().unwrap();
 
-        // Calculate what the sum is before realizing the current node
+        // `sum_at_node` corresponds to everything to the left and in the current node.
+        // We don't know which component of the current node, if any, will be included, so we remove the whole thing.
+        // 
+        // Sanity check: for the root node, this will be 0, since the "current node" is the root and includes the whole
+        // tree (so when it is removed, there is nothing left)
         let sum_at_node = current_sum.checked_sub(node.get_value())?;
         // Calculate how much of the node has been realized in a previous sync
         let diff_at_node = prev_sum.saturating_sub(sum_at_node);

--- a/contracts/sumtree-orderbook/src/sumtree/tree.rs
+++ b/contracts/sumtree-orderbook/src/sumtree/tree.rs
@@ -143,8 +143,12 @@ fn prefix_sum_walk(
         // would be zero and the target ETAS would remain unchanged.
         let new_etas = target_etas.checked_add(unrealized_from_left)?;
 
-        // if the new ETAS is greater than or equal to the right child's min range, we can walk right
+        // If the new ETAS is greater than or equal to the right child's min range, we can walk right
         // as the left node MUST be realizable given the invariants of the sumtree mechanism
+        //
+        // Intuition: If all swaps and cancels from the left child put us in the cancel territory of the right side, then we
+        // don't care about the ordering of the swaps and cancels on the left. We know that all the cancels need to be
+        // realized, so we batch realize them by adding *their unrealized portion* to our target ETAS and walking right.
         if new_etas >= right_child.get_min_range() {
             return prefix_sum_walk(storage, &right_child, current_sum, new_etas, prev_sum);
         }

--- a/contracts/sumtree-orderbook/src/sumtree/tree.rs
+++ b/contracts/sumtree-orderbook/src/sumtree/tree.rs
@@ -125,7 +125,15 @@ fn prefix_sum_walk(
         // Concretely, if this value is ever nonzero for a node, the amount corresponds exactly to the amount realized
         // below the node at the end of the previous sync. In all other cases, it will snap to zero due to the saturating sub.
         let diff_at_node = prev_sum.saturating_sub(sum_at_node);
-        // Calculate how much of the left node is unrealized
+        // `unrealized_from_left` is the amount in the left child that remained unrealized at the end of the previous
+        // sync.
+        //
+        // If the left child is fully realized then the subtraction here will either be zero (if none of the right child is
+        // realized) or negative (if some of the right child is realized), since `diff_at_node` = amount realized below left
+        // and below right children. Saturating sub will ensure both of these cases snap to zero.
+        // 
+        // Thus, if this value is ever nonzero, it means that the left child had some unrealized cancels in it, and the
+        // amount corresponds exactly to `unrealized_from_left`.
         let unrealized_from_left = left_child.get_value().saturating_sub(diff_at_node);
         // Calculate the new ETAS after realizing what is unrealized from the left node
         let new_etas = target_etas.checked_add(unrealized_from_left)?;

--- a/contracts/sumtree-orderbook/src/tests/test_order.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_order.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use crate::{
     constants::{MAX_TICK, MIN_TICK}, error::ContractError, order::*, orderbook::*, state::*, sumtree::{
-        node::{NodeType, TreeNode},tree::get_root_node
+        node::{NodeType, TreeNode}, test::test_node::print_tree, tree::{get_or_init_root_node, get_root_node}
     },
     tests::{mock_querier::mock_dependencies_custom, test_utils::{decimal256_from_u128, place_multiple_limit_orders}},
     types::{
@@ -4248,13 +4248,13 @@ fn test_cancelled_orders() {
 
     // Tree after cancelling every order that is not evenly divisible by 3:
     //
-    //                                                      5: 6 1-9                                                                
-    //                           ┌────────────────────────────────────────────────────────────────────┐                                
-    //                       1: 2 1-3                                                           9: 4 4-9                                
-    //           ┌────────────────────────────────┐                                ┌────────────────────────────────┐                
-    //         2: 1 1                          3: 2 1                            7: 2 4-6                       11: 2 7-9                
+    //                                                  5: 12 2-18                                                                
+    //                      ┌────────────────────────────────────────────────────────────────────┐                                
+    //                      1: 4 2-6                                                       9: 8 8-18                                
+    //         ┌────────────────────────────────┐                                ┌────────────────────────────────┐                
+    //      2: 2 2                          3: 4 2                           7: 4 8-12                      11: 4 14-18                
     //                                                                  ┌────────────────┐                ┌────────────────┐        
-    //                                                              4: 4 1          6: 5 1             8: 7 1         10: 8 1    
+    //                                                               4: 8 2         6: 10 2            8: 14 2         10: 16 2   
 
     // Last order should be unclaimable
     let err = OrderOperation::Claim((0, 9)).run(deps.as_mut(), env.clone(), info.clone()).unwrap_err();

--- a/contracts/sumtree-orderbook/src/tests/test_query.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_query.rs
@@ -1932,7 +1932,7 @@ fn test_ticks_by_id() {
                     cumulative_total_value: decimal256_from_u128(2u8),
                     effective_total_amount_swapped: decimal256_from_u128(2u8),
                     cumulative_realized_cancels: Decimal256::one(),
-                    last_tick_sync_etas: Decimal256::zero(),
+                    last_tick_sync_etas: Decimal256::one(),
                 },
                 bid_values: TickValues::default(),
             }],

--- a/contracts/sumtree-orderbook/src/tests/test_tick.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_tick.rs
@@ -469,12 +469,6 @@ fn test_sync_tick() {
         // --- System under test ---
 
         for _ in 0..test.num_syncs {
-            let TickState {
-                bid_values: pre_bid_tick_values,
-                ask_values: pre_ask_tick_values,
-            } = TICK_STATE
-                .load(deps.as_ref().storage, default_tick_id)
-                .unwrap();
             // Increment tick ETAS for each step
             let (updated_bid_etas, updated_ask_etas) = increment_tick_etas(
                 deps.as_mut().storage,
@@ -492,26 +486,6 @@ fn test_sync_tick() {
                 updated_ask_etas,
             )
             .unwrap();
-
-            let TickState {
-                bid_values: post_bid_tick_values,
-                ask_values: post_ask_tick_values,
-            } = TICK_STATE
-                .load(deps.as_ref().storage, default_tick_id)
-                .unwrap();
-
-            assert!(
-                pre_bid_tick_values.effective_total_amount_swapped
-                    <= post_bid_tick_values.effective_total_amount_swapped,
-                "ETAS decreased for bid on new sync: {}",
-                test.name
-            );
-            assert!(
-                pre_ask_tick_values.effective_total_amount_swapped
-                    <= post_ask_tick_values.effective_total_amount_swapped,
-                "ETAS decreased for ask on new sync: {}",
-                test.name
-            );
         }
 
         // --- Assertions ---

--- a/contracts/sumtree-orderbook/src/tests/test_tick.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_tick.rs
@@ -133,19 +133,19 @@ fn test_sync_tick() {
             // Iteration 1: only node 1 is included
             // Iteration 2: first two nodes included
             // Iteration 3: first four nodes are incldued
-            new_bid_etas_per_sync: Decimal256::from_ratio(30u128, 1u128),
+            new_bid_etas_per_sync: Decimal256::from_ratio(7u128, 1u128),
             new_ask_etas_per_sync: Decimal256::zero(),
             num_syncs: 4,
 
-            // By end of iteration 3, the amounts of the first four nodes should be included.
+            // By end of iteration 4, the amounts of the first four nodes should be included.
             // This is equal to 30 + 12 + 10 + 28 = 80
             expected_cumulative_realized_bid: Decimal256::from_ratio(80u128, 1u128),
             expected_cumulative_realized_ask: Decimal256::zero(),
 
-            // The new ETAS includes all the incremented amounts (3 * 30 each) which represent fills,
+            // The new ETAS includes all the incremented amounts (4 * 7 each) which represent fills,
             // plus the amount of realized cancellations
             expected_new_bid_etas_post_sync: Decimal256::from_ratio(
-                (4u128 * 30u128) + 80u128,
+                (4u128 * 7u128) + 80u128,
                 1u128,
             ),
             expected_new_ask_etas_post_sync: Decimal256::zero(),
@@ -252,7 +252,7 @@ fn test_sync_tick() {
             // Iteration 1: only node 1 is included
             // Iteration 2: first two nodes included
             // Iteration 3: first four nodes are included
-            new_ask_etas_per_sync: Decimal256::from_ratio(30u128, 1u128),
+            new_ask_etas_per_sync: Decimal256::from_ratio(7u128, 1u128),
             new_bid_etas_per_sync: Decimal256::zero(),
             num_syncs: 4,
 
@@ -261,10 +261,10 @@ fn test_sync_tick() {
             expected_cumulative_realized_ask: Decimal256::from_ratio(80u128, 1u128),
             expected_cumulative_realized_bid: Decimal256::zero(),
 
-            // The new ETAS includes all the incremented amounts (3 * 30 each) which represent fills,
+            // The new ETAS includes all the incremented amounts (4 * 7 each) which represent fills,
             // plus the amount of realized cancellations
             expected_new_ask_etas_post_sync: Decimal256::from_ratio(
-                (4u128 * 30u128) + 80u128,
+                (4u128 * 7u128) + 80u128,
                 1u128,
             ),
             expected_new_bid_etas_post_sync: Decimal256::zero(),
@@ -305,7 +305,7 @@ fn test_sync_tick() {
 
             // Multiple unrealized cancels for both bid and ask
             unrealized_cancels_bid: vec![
-                NodeType::leaf_uint256(35u32, 25u32),
+                NodeType::leaf_uint256(45u32, 25u32),
                 NodeType::leaf_uint256(10u32, 25u32),
             ],
             unrealized_cancels_ask: vec![
@@ -314,7 +314,7 @@ fn test_sync_tick() {
             ],
 
             // Increment tick ETAS by 10 for bid and 40 for ask per iteration for 2 iterations
-            new_bid_etas_per_sync: Decimal256::from_ratio(10u128, 1u128),
+            new_bid_etas_per_sync: Decimal256::from_ratio(5u128, 1u128),
             new_ask_etas_per_sync: Decimal256::from_ratio(40u128, 1u128),
             num_syncs: 2,
 
@@ -325,7 +325,7 @@ fn test_sync_tick() {
             // The new ETAS includes all the incremented amounts which represent fills,
             // plus the amount of realized cancellations for both bid and ask
             expected_new_bid_etas_post_sync: Decimal256::from_ratio(
-                (2u128 * 10u128) + 25u128,
+                (2u128 * 5u128) + 25u128,
                 1u128,
             ),
             expected_new_ask_etas_post_sync: Decimal256::from_ratio(

--- a/contracts/sumtree-orderbook/src/tests/test_utils.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_utils.rs
@@ -79,8 +79,7 @@ impl OrderOperation {
                     env.contract.address,
                     tick_id,
                     order_id,
-                )
-                .unwrap();
+                )?;
                 Ok(())
             }
             OrderOperation::Cancel((tick_id, order_id)) => {
@@ -88,7 +87,7 @@ impl OrderOperation {
                     .load(deps.as_ref().storage, &(tick_id, order_id))
                     .unwrap();
                 let info = mock_info(order.owner.as_str(), &[]);
-                cancel_limit(deps, env, info, tick_id, order_id).unwrap();
+                cancel_limit(deps, env, info, tick_id, order_id)?;
                 Ok(())
             }
         }

--- a/contracts/sumtree-orderbook/src/tick.rs
+++ b/contracts/sumtree-orderbook/src/tick.rs
@@ -74,6 +74,7 @@ pub fn sync_tick(
             .effective_total_amount_swapped
             .checked_add(realized_since_last_sync)?;
         tick_value.cumulative_realized_cancels = new_cumulative_realized_cancels;
+        tick_value.last_tick_sync_etas = target_etas;
 
         // Defense in depth guardrail: ensure that tick sync does not push tick ETAS past CTT.
         ensure!(

--- a/contracts/sumtree-orderbook/src/tick.rs
+++ b/contracts/sumtree-orderbook/src/tick.rs
@@ -59,8 +59,14 @@ pub fn sync_tick(
 
         // Calculate the growth in realized cancels since previous sync.
         // This is equivalent to the amount we will need to add to the tick's ETAS.
-        let realized_since_last_sync =
-            new_cumulative_realized_cancels.checked_sub(old_cumulative_realized_cancels)?;
+        let realized_since_last_sync = new_cumulative_realized_cancels
+            .checked_sub(old_cumulative_realized_cancels)
+            .map_err(|_| ContractError::InvalidPrefixSum {
+                error: Some(format!(
+                    "New prefix sum less than previous, previous: {}, new: {}",
+                    old_cumulative_realized_cancels, new_cumulative_realized_cancels
+                )),
+            })?;
 
         // Update the tick state to represent new ETAS and new cumulative realized cancels.
         tick_value.effective_total_amount_swapped = tick_value

--- a/contracts/sumtree-orderbook/src/tick.rs
+++ b/contracts/sumtree-orderbook/src/tick.rs
@@ -55,7 +55,8 @@ pub fn sync_tick(
 
         // Assuming `calculate_prefix_sum` is a function that calculates the prefix sum at the given ETAS.
         // This function needs to be implemented based on your sumtree structure and logic.
-        let new_cumulative_realized_cancels = get_prefix_sum(storage, tree, target_etas)?;
+        let new_cumulative_realized_cancels =
+            get_prefix_sum(storage, tree, target_etas, old_cumulative_realized_cancels)?;
 
         // Calculate the growth in realized cancels since previous sync.
         // This is equivalent to the amount we will need to add to the tick's ETAS.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change
In the sumtree mechanism there is a case where realizing a left node causes the right node to meet criteria to be realized. This is a tricky situation to cover without resyncing the node after a sync is complete (leading to O(n) worst case runtime). 

The naiive approach is to check if realizing the left node pushes the target ETAS over the right node's minimum boundary, but this causes a case where a left node may be synced multiple times (as the current implementation has no awareness whether or not a node has been realized). If a node is realized multiple times we incur a case where an order may be marked as filled when it is not and the price will run out of liquidity eventually as it is not in balance.

To counter the above we can give `prefix_sum_walk` context of what has been realized in the form of the previous sum. This opens the possibility of the following check:

1. Both left and right node exist
2. Check if anything of the left node has not been synced: 

```
Amount Realized Before Node = (Current Sum - Current Node Value)
Amount Realized Previously At Node = max(Previous Sum - Amount Realized Before Node, 0)
Unrealized From Left= Value of Left Child - Amount Realized Previously At Node
```

3. If syncing the left node pushes the target ETAS over the right minimum then we can walk right:

```
Right Min >= Left Realizable Amount + Target ETAS
```

This calculation should circumvent resyncing by realizing that resyncing will cause the right node to be included in the prefix sum. The implementation is as follows:

``` rust
if left_child.is_some() && right_child.is_some() {
        let left_child = left_child.clone().unwrap();
        let right_child = right_child.clone().unwrap();

        let sum_at_node = current_sum.checked_sub(node.get_value())?;
        let diff_at_node = prev_sum.saturating_sub(sum_at_node);
        let unrealized_from_left = left_child.get_value().saturating_sub(diff_at_node);
        let new_etas = target_etas.checked_add(unrealized_from_left)?;

        if new_etas >= right_child.get_min_range() {
            return prefix_sum_walk(storage, &right_child, current_sum, new_etas, prev_sum);
        }
}
```

## Testing and Verifying
Tests that used `prefix_sum_walk` were updated accordingly. Some have had the previous sum set as the current root node value (to simulate an explicit tree walk without the above condition) but should have test cases added in future for the above.
