### PR TITLE
[Sumtree]: Order Placed Timestamp

### DIFF
--- a/contracts/sumtree-orderbook/src/order.rs
+++ b/contracts/sumtree-orderbook/src/order.rs
@@ -22,7 +22,7 @@ use cw_utils::{must_pay, nonpayable};
 #[allow(clippy::manual_range_contains, clippy::too_many_arguments)]
 pub fn place_limit(
     deps: &mut DepsMut,
-    _env: Env,
+    env: Env,
     info: MessageInfo,
     tick_id: i64,
     order_direction: OrderDirection,
@@ -102,7 +102,8 @@ pub fn place_limit(
         quantity,
         tick_values.cumulative_total_value,
         claim_bounty,
-    );
+    )
+    .with_placed_at(env.block.time);
 
     let quant_dec256 = Decimal256::from_ratio(limit_order.quantity.u128(), Uint256::one());
     // Only save the order if not fully filled

--- a/contracts/sumtree-orderbook/src/tests/test_order.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_order.rs
@@ -2776,7 +2776,7 @@ fn test_claim_order() {
         // Claim designated order
         let res = claim_limit(
             deps.as_mut(),
-            env,
+            env.clone(),
             info,
             test.tick_id,
             test.order_id,
@@ -2818,7 +2818,7 @@ fn test_claim_order() {
         // Order in state may have been removed
         assert_eq!(
             maybe_order,
-            test.expected_order_state,
+            test.expected_order_state.map(|o| o.with_placed_at(env.block.time)),
             "{}",
             format_test_name(test.name)
         );
@@ -3476,7 +3476,7 @@ fn test_claim_order_moving_tick() {
         // Claim designated order
         let res = claim_limit(
             deps.as_mut(),
-            env,
+            env.clone(),
             info,
             test.tick_id,
             test.order_id,
@@ -3504,7 +3504,7 @@ fn test_claim_order_moving_tick() {
         // Order in state may have been removed
         assert_eq!(
             maybe_order,
-            test.expected_order_state,
+            test.expected_order_state.map(|o| o.with_placed_at(env.block.time)),
             "{}",
             format_test_name(test.name)
         );
@@ -3693,7 +3693,7 @@ fn test_batch_claim_order() {
         let info = mock_info(sender.as_str(), &[]);
 
         // Batch claim orders
-        let res = batch_claim_limits(deps.as_mut(), info.clone(), env, test.orders.clone());
+        let res = batch_claim_limits(deps.as_mut(), info.clone(), env.clone(), test.orders.clone());
 
         if let Some(err) = test.expected_error {
             assert_eq!(res, Err(err), "{}", format_test_name(test.name));
@@ -3739,7 +3739,7 @@ fn test_batch_claim_order() {
                     .find(|order| order.tick_id == *tick_id && order.order_id == *order_id)
             });
             assert_eq!(
-                expected_order_state.cloned(),
+                expected_order_state.cloned().map(|o| o.with_placed_at(env.block.time)),
                 maybe_order,
                 "{} for order_id {} and tick_id {}",
                 format_test_name(test.name),

--- a/contracts/sumtree-orderbook/src/tests/test_query.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_query.rs
@@ -1452,7 +1452,11 @@ fn test_orders_by_owner() {
             );
         });
         assert_eq!(
-            res, test.expected_output,
+            res,
+            test.expected_output
+                .iter()
+                .map(|o| o.clone().with_placed_at(env.block.time))
+                .collect::<Vec<LimitOrder>>(),
             "{}: output did not match",
             test.name
         );

--- a/contracts/sumtree-orderbook/src/tests/test_utils.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_utils.rs
@@ -108,17 +108,15 @@ pub(crate) fn generate_limit_orders(
     let mut orders = Vec::new();
     for &tick_id in tick_ids {
         for _ in 0..orders_per_tick {
-            let order = LimitOrder {
+            let order = LimitOrder::new(
                 tick_id,
+                0,
                 order_direction,
-                owner: Addr::unchecked(DEFAULT_OWNER),
-                quantity: quantity_per_order,
-                placed_quantity: quantity_per_order,
-                // We set these values to zero since they will be unused anyway
-                order_id: 0,
-                etas: Decimal256::zero(),
-                claim_bounty: None,
-            };
+                Addr::unchecked(DEFAULT_OWNER),
+                quantity_per_order,
+                Decimal256::zero(),
+                None,
+            );
             orders.push(order);
         }
     }

--- a/contracts/sumtree-orderbook/src/types/order.rs
+++ b/contracts/sumtree-orderbook/src/types/order.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::fmt::Display;
 
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Decimal256, Uint128};
+use cosmwasm_std::{Addr, Decimal256, Timestamp, Uint128};
 
 #[cw_serde]
 #[derive(Copy)]
@@ -47,6 +47,8 @@ pub struct LimitOrder {
     pub claim_bounty: Option<Decimal256>,
     // Immutable quantity of the order when placed
     pub placed_quantity: Uint128,
+    #[serde(default)]
+    pub placed_at: Timestamp,
 }
 
 impl LimitOrder {
@@ -69,12 +71,18 @@ impl LimitOrder {
             etas,
             claim_bounty,
             placed_quantity: quantity,
+            placed_at: Timestamp::default(),
         }
     }
 
     #[cfg(test)]
     pub(crate) fn with_placed_quantity(mut self, quantity: impl Into<Uint128>) -> Self {
         self.placed_quantity = quantity.into();
+        self
+    }
+
+    pub(crate) fn with_placed_at(mut self, placed_at: Timestamp) -> Self {
+        self.placed_at = placed_at;
         self
     }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change
These changes add a `placed_at` field to limit orders that records when a particular order was placed using the `env.block.time` parameter for the `execute` entry point.

## Testing and Verifying
A concern for this change was deserializing orders placed in a previous contract version that may not have this field. I uploaded an old version of the contract (without `placed_at`) placed an [order](https://www.mintscan.io/osmosis-testnet/tx/7A2AE97573E29D70F2DAEEDC76B5AC2345F3BC24B4A7BD99646A1DAD40098E55?sector=logs), [uploaded the new contract](https://www.mintscan.io/osmosis-testnet/tx/B1F7773EDC7E5E96B09A80DC38558F4509C6BF07D03A072050CC7ACAE69E1874?sector=message), [migrated the contract](https://www.mintscan.io/osmosis-testnet/tx/CAECF418F1529034EE925FF908412D349AACAA9F7A228498DD568DB8B1743772?sector=message) and queried the order again (the second order is one placed after the update):

```json
{
  "data": [
    {
      "tick_id": 0,
      "order_id": 0,
      "order_direction": "ask",
      "owner": "osmo18rzhuqjz392p4j5nn2y4paeqa8ewsw67eznzv5",
      "quantity": "10",
      "etas": "0",
      "claim_bounty": null,
      "placed_quantity": "10",
      "placed_at": "0"
    },
    {
      "tick_id": 0,
      "order_id": 1,
      "order_direction": "ask",
      "owner": "osmo18rzhuqjz392p4j5nn2y4paeqa8ewsw67eznzv5",
      "quantity": "10",
      "etas": "10",
      "claim_bounty": null,
      "placed_quantity": "10",
      "placed_at": "1719417870545592240"
    }
  ]
}
```