### PR TITLE
[Sumtree]: Orders by Tick Query

### DIFF
--- a/contracts/sumtree-orderbook/src/contract.rs
+++ b/contracts/sumtree-orderbook/src/contract.rs
@@ -143,13 +143,13 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
         } => Ok(to_json_binary(&query::orders_by_owner(
             deps, owner, start_from, end_at, limit,
         )?)?),
-        QueryMsg::OrdersByTick {
-            tick_id,
+        QueryMsg::OrdersByTicks {
+            tick_ids,
             start_from,
             end_at,
             limit,
         } => Ok(to_json_binary(&query::orders_by_tick(
-            deps, tick_id, start_from, end_at, limit,
+            deps, tick_ids, start_from, end_at, limit,
         )?)?),
         QueryMsg::Denoms {} => Ok(to_json_binary(&query::denoms(deps)?)?),
         QueryMsg::GetMakerFee {} => Ok(to_json_binary(&state::get_maker_fee(deps.storage)?)?),

--- a/contracts/sumtree-orderbook/src/contract.rs
+++ b/contracts/sumtree-orderbook/src/contract.rs
@@ -143,13 +143,13 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
         } => Ok(to_json_binary(&query::orders_by_owner(
             deps, owner, start_from, end_at, limit,
         )?)?),
-        QueryMsg::OrdersByTicks {
-            tick_ids,
+        QueryMsg::OrdersByTick {
+            tick_id,
             start_from,
             end_at,
             limit,
-        } => Ok(to_json_binary(&query::orders_by_ticks(
-            deps, tick_ids, start_from, end_at, limit,
+        } => Ok(to_json_binary(&query::orders_by_tick(
+            deps, tick_id, start_from, end_at, limit,
         )?)?),
         QueryMsg::Denoms {} => Ok(to_json_binary(&query::denoms(deps)?)?),
         QueryMsg::GetMakerFee {} => Ok(to_json_binary(&state::get_maker_fee(deps.storage)?)?),

--- a/contracts/sumtree-orderbook/src/contract.rs
+++ b/contracts/sumtree-orderbook/src/contract.rs
@@ -148,7 +148,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
             start_from,
             end_at,
             limit,
-        } => Ok(to_json_binary(&query::orders_by_tick(
+        } => Ok(to_json_binary(&query::orders_by_ticks(
             deps, tick_ids, start_from, end_at, limit,
         )?)?),
         QueryMsg::Denoms {} => Ok(to_json_binary(&query::denoms(deps)?)?),

--- a/contracts/sumtree-orderbook/src/contract.rs
+++ b/contracts/sumtree-orderbook/src/contract.rs
@@ -143,6 +143,14 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
         } => Ok(to_json_binary(&query::orders_by_owner(
             deps, owner, start_from, end_at, limit,
         )?)?),
+        QueryMsg::OrdersByTick {
+            tick_id,
+            start_from,
+            end_at,
+            limit,
+        } => Ok(to_json_binary(&query::orders_by_tick(
+            deps, tick_id, start_from, end_at, limit,
+        )?)?),
         QueryMsg::Denoms {} => Ok(to_json_binary(&query::denoms(deps)?)?),
         QueryMsg::GetMakerFee {} => Ok(to_json_binary(&state::get_maker_fee(deps.storage)?)?),
 

--- a/contracts/sumtree-orderbook/src/msg.rs
+++ b/contracts/sumtree-orderbook/src/msg.rs
@@ -120,8 +120,8 @@ pub enum QueryMsg {
     },
 
     #[returns(OrdersResponse)]
-    OrdersByTicks {
-        tick_ids: Vec<i64>,
+    OrdersByTick {
+        tick_id: i64,
         start_from: Option<u64>,
         end_at: Option<u64>,
         limit: Option<u64>,

--- a/contracts/sumtree-orderbook/src/msg.rs
+++ b/contracts/sumtree-orderbook/src/msg.rs
@@ -1,4 +1,4 @@
-use crate::types::{OrderDirection, TickState};
+use crate::types::{LimitOrder, OrderDirection, TickState};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Coin, Decimal, Decimal256, Uint128, Uint256};
 use osmosis_std::types::cosmos::base::v1beta1::Coin as ProtoCoin;
@@ -119,6 +119,14 @@ pub enum QueryMsg {
         limit: Option<u64>,
     },
 
+    #[returns(OrdersResponse)]
+    OrdersByTick {
+        tick_id: i64,
+        start_from: Option<u64>,
+        end_at: Option<u64>,
+        limit: Option<u64>,
+    },
+
     #[returns(DenomsResponse)]
     Denoms {},
 }
@@ -171,6 +179,12 @@ pub struct TickIdAndState {
 #[cw_serde]
 pub struct AllTicksResponse {
     pub ticks: Vec<TickIdAndState>,
+}
+
+#[cw_serde]
+pub struct OrdersResponse {
+    pub orders: Vec<LimitOrder>,
+    pub count: u64,
 }
 
 #[cw_serde]

--- a/contracts/sumtree-orderbook/src/msg.rs
+++ b/contracts/sumtree-orderbook/src/msg.rs
@@ -120,8 +120,8 @@ pub enum QueryMsg {
     },
 
     #[returns(OrdersResponse)]
-    OrdersByTick {
-        tick_id: i64,
+    OrdersByTicks {
+        tick_ids: Vec<i64>,
         start_from: Option<u64>,
         end_at: Option<u64>,
         limit: Option<u64>,

--- a/contracts/sumtree-orderbook/src/query.rs
+++ b/contracts/sumtree-orderbook/src/query.rs
@@ -217,7 +217,7 @@ pub(crate) fn denoms(deps: Deps) -> ContractResult<DenomsResponse> {
     })
 }
 
-pub(crate) fn orders_by_tick(
+pub(crate) fn orders_by_ticks(
     deps: Deps,
     tick_ids: Vec<i64>,
     start_from: Option<u64>,

--- a/contracts/sumtree-orderbook/src/query.rs
+++ b/contracts/sumtree-orderbook/src/query.rs
@@ -8,10 +8,12 @@ use crate::{
     error::ContractResult,
     msg::{
         AllTicksResponse, CalcOutAmtGivenInResponse, DenomsResponse, GetSwapFeeResponse,
-        GetTotalPoolLiquidityResponse, SpotPriceResponse, TickIdAndState,
+        GetTotalPoolLiquidityResponse, OrdersResponse, SpotPriceResponse, TickIdAndState,
     },
     order,
-    state::{get_directional_liquidity, get_orders_by_owner, IS_ACTIVE, ORDERBOOK, TICK_STATE},
+    state::{
+        get_directional_liquidity, get_orders_by_owner, orders, IS_ACTIVE, ORDERBOOK, TICK_STATE,
+    },
     sudo::ensure_swap_fee,
     tick_math::tick_to_price,
     types::{FilterOwnerOrders, LimitOrder, MarketOrder, OrderDirection},
@@ -212,5 +214,34 @@ pub(crate) fn denoms(deps: Deps) -> ContractResult<DenomsResponse> {
     Ok(DenomsResponse {
         quote_denom: orderbook.quote_denom,
         base_denom: orderbook.base_denom,
+    })
+}
+
+pub(crate) fn orders_by_tick(
+    deps: Deps,
+    tick_id: i64,
+    start_from: Option<u64>,
+    end_at: Option<u64>,
+    limit: Option<u64>,
+) -> ContractResult<OrdersResponse> {
+    let count = orders()
+        .prefix(tick_id)
+        .keys(deps.storage, None, None, Order::Ascending)
+        .count();
+    let orders = orders()
+        .prefix(tick_id)
+        .range(
+            deps.storage,
+            start_from.map(Bound::inclusive),
+            end_at.map(Bound::inclusive),
+            Order::Ascending,
+        )
+        .take(limit.unwrap_or(count as u64) as usize)
+        .map(|res| res.unwrap().1)
+        .collect();
+
+    Ok(OrdersResponse {
+        count: count as u64,
+        orders,
     })
 }

--- a/contracts/sumtree-orderbook/src/query.rs
+++ b/contracts/sumtree-orderbook/src/query.rs
@@ -226,7 +226,12 @@ pub(crate) fn orders_by_tick(
 ) -> ContractResult<OrdersResponse> {
     let count = orders()
         .prefix(tick_id)
-        .keys(deps.storage, None, None, Order::Ascending)
+        .keys(
+            deps.storage,
+            start_from.map(Bound::inclusive),
+            end_at.map(Bound::inclusive),
+            Order::Ascending,
+        )
         .count();
     let orders = orders()
         .prefix(tick_id)

--- a/contracts/sumtree-orderbook/src/query.rs
+++ b/contracts/sumtree-orderbook/src/query.rs
@@ -217,41 +217,31 @@ pub(crate) fn denoms(deps: Deps) -> ContractResult<DenomsResponse> {
     })
 }
 
-pub(crate) fn orders_by_ticks(
+pub(crate) fn orders_by_tick(
     deps: Deps,
-    tick_ids: Vec<i64>,
+    tick_id: i64,
     start_from: Option<u64>,
     end_at: Option<u64>,
     limit: Option<u64>,
 ) -> ContractResult<OrdersResponse> {
-    let mut count = 0;
-    let mut all_orders: Vec<LimitOrder> = vec![];
-    for tick_id in tick_ids {
-        let mut order_count = orders()
-            .prefix(tick_id)
-            .keys(deps.storage, None, None, Order::Ascending)
-            .count();
-        if let Some(limit) = limit {
-            order_count = order_count.min((limit as usize) - count);
-        }
-
-        let orders_for_tick: Vec<LimitOrder> = orders()
-            .prefix(tick_id)
-            .range(
-                deps.storage,
-                start_from.map(Bound::inclusive),
-                end_at.map(Bound::inclusive),
-                Order::Ascending,
-            )
-            .take(order_count)
-            .map(|res| res.unwrap().1)
-            .collect();
-        all_orders.extend(orders_for_tick);
-        count += order_count;
-    }
+    let count = orders()
+        .prefix(tick_id)
+        .keys(deps.storage, None, None, Order::Ascending)
+        .count();
+    let orders = orders()
+        .prefix(tick_id)
+        .range(
+            deps.storage,
+            start_from.map(Bound::inclusive),
+            end_at.map(Bound::inclusive),
+            Order::Ascending,
+        )
+        .take(limit.unwrap_or(count as u64) as usize)
+        .map(|res| res.unwrap().1)
+        .collect();
 
     Ok(OrdersResponse {
         count: count as u64,
-        orders: all_orders,
+        orders,
     })
 }

--- a/contracts/sumtree-orderbook/src/tests/test_query.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_query.rs
@@ -1776,7 +1776,11 @@ fn test_orders_by_ticks() {
             );
         });
         assert_eq!(
-            res.orders, test.expected_output,
+            res.orders,
+            test.expected_output
+                .iter()
+                .map(|o| o.clone().with_placed_at(env.block.time))
+                .collect::<Vec<LimitOrder>>(),
             "{}: output did not match",
             test.name
         );

--- a/contracts/sumtree-orderbook/src/tests/test_query.rs
+++ b/contracts/sumtree-orderbook/src/tests/test_query.rs
@@ -1458,3 +1458,328 @@ fn test_orders_by_owner() {
         );
     }
 }
+
+struct TestOrdersByTicksCase {
+    name: &'static str,
+    pre_operations: Vec<OrderOperation>,
+    expected_output: Vec<LimitOrder>,
+    expected_count: u64,
+    tick_id: i64,
+    limit: Option<u64>,
+    start_from: Option<u64>,
+    end_at: Option<u64>,
+    expected_error: Option<ContractError>,
+}
+
+#[test]
+fn test_orders_by_ticks() {
+    let test_cases = vec![
+        TestOrdersByTicksCase {
+            name: "no orders",
+            pre_operations: vec![],
+            expected_output: vec![],
+            expected_count: 0,
+            tick_id: 0,
+            limit: None,
+            start_from: None,
+            end_at: None,
+            expected_error: None,
+        },
+        TestOrdersByTicksCase {
+            name: "single order",
+            pre_operations: vec![OrderOperation::PlaceLimit(LimitOrder::new(
+                0,
+                0,
+                OrderDirection::Bid,
+                Addr::unchecked("sender"),
+                Uint128::from(100u128),
+                Decimal256::zero(),
+                None,
+            ))],
+            expected_output: vec![LimitOrder::new(
+                0,
+                0,
+                OrderDirection::Bid,
+                Addr::unchecked("sender"),
+                Uint128::from(100u128),
+                Decimal256::zero(),
+                None,
+            )],
+            expected_count: 1,
+            tick_id: 0,
+            limit: None,
+            expected_error: None,
+            start_from: None,
+            end_at: None,
+        },
+        TestOrdersByTicksCase {
+            name: "multiple orders",
+            pre_operations: vec![
+                OrderOperation::PlaceLimit(LimitOrder::new(
+                    1,
+                    0,
+                    OrderDirection::Bid,
+                    Addr::unchecked("owner"),
+                    Uint128::new(100),
+                    Decimal256::zero(),
+                    None,
+                )),
+                OrderOperation::PlaceLimit(LimitOrder::new(
+                    1,
+                    1,
+                    OrderDirection::Ask,
+                    Addr::unchecked("owner"),
+                    Uint128::new(200),
+                    Decimal256::zero(),
+                    None,
+                )),
+            ],
+            expected_output: vec![
+                LimitOrder::new(
+                    1,
+                    0,
+                    OrderDirection::Bid,
+                    Addr::unchecked("owner"),
+                    Uint128::new(100),
+                    Decimal256::zero(),
+                    None,
+                ),
+                LimitOrder::new(
+                    1,
+                    1,
+                    OrderDirection::Ask,
+                    Addr::unchecked("owner"),
+                    Uint128::new(200),
+                    Decimal256::zero(),
+                    None,
+                ),
+            ],
+            expected_count: 2,
+            tick_id: 1,
+            limit: None,
+            expected_error: None,
+            start_from: None,
+            end_at: None,
+        },
+        TestOrdersByTicksCase {
+            name: "multiple orders w/ limit",
+            pre_operations: vec![
+                OrderOperation::PlaceLimit(LimitOrder::new(
+                    1,
+                    0,
+                    OrderDirection::Bid,
+                    Addr::unchecked("owner"),
+                    Uint128::new(100),
+                    Decimal256::zero(),
+                    None,
+                )),
+                OrderOperation::PlaceLimit(LimitOrder::new(
+                    1,
+                    1,
+                    OrderDirection::Ask,
+                    Addr::unchecked("owner"),
+                    Uint128::new(200),
+                    Decimal256::zero(),
+                    None,
+                )),
+                OrderOperation::PlaceLimit(LimitOrder::new(
+                    1,
+                    2,
+                    OrderDirection::Bid,
+                    Addr::unchecked("owner"),
+                    Uint128::new(100),
+                    Decimal256::zero(),
+                    None,
+                )),
+            ],
+            expected_output: vec![
+                LimitOrder::new(
+                    1,
+                    0,
+                    OrderDirection::Bid,
+                    Addr::unchecked("owner"),
+                    Uint128::new(100),
+                    Decimal256::zero(),
+                    None,
+                ),
+                LimitOrder::new(
+                    1,
+                    1,
+                    OrderDirection::Ask,
+                    Addr::unchecked("owner"),
+                    Uint128::new(200),
+                    Decimal256::zero(),
+                    None,
+                ),
+            ],
+            expected_count: 3,
+            tick_id: 1,
+            limit: Some(2),
+            start_from: None,
+            end_at: None,
+            expected_error: None,
+        },
+        TestOrdersByTicksCase {
+            name: "multiple orders w/ limit + start from",
+            pre_operations: vec![
+                OrderOperation::PlaceLimit(LimitOrder::new(
+                    1,
+                    0,
+                    OrderDirection::Bid,
+                    Addr::unchecked("owner"),
+                    Uint128::new(100),
+                    Decimal256::zero(),
+                    None,
+                )),
+                OrderOperation::PlaceLimit(LimitOrder::new(
+                    1,
+                    1,
+                    OrderDirection::Ask,
+                    Addr::unchecked("owner"),
+                    Uint128::new(200),
+                    Decimal256::zero(),
+                    None,
+                )),
+                OrderOperation::PlaceLimit(LimitOrder::new(
+                    1,
+                    2,
+                    OrderDirection::Bid,
+                    Addr::unchecked("owner"),
+                    Uint128::new(100),
+                    Decimal256::zero(),
+                    None,
+                )),
+            ],
+            expected_output: vec![
+                LimitOrder::new(
+                    1,
+                    1,
+                    OrderDirection::Ask,
+                    Addr::unchecked("owner"),
+                    Uint128::new(200),
+                    Decimal256::zero(),
+                    None,
+                ),
+                LimitOrder::new(
+                    1,
+                    2,
+                    OrderDirection::Bid,
+                    Addr::unchecked("owner"),
+                    Uint128::new(100),
+                    decimal256_from_u128(100u128),
+                    None,
+                ),
+            ],
+            expected_count: 2,
+            tick_id: 1,
+            limit: Some(2),
+            start_from: Some(1),
+            end_at: None,
+            expected_error: None,
+        },
+        TestOrdersByTicksCase {
+            name: "multiple orders w/ limit + end at",
+            pre_operations: vec![
+                OrderOperation::PlaceLimit(LimitOrder::new(
+                    1,
+                    0,
+                    OrderDirection::Bid,
+                    Addr::unchecked("owner"),
+                    Uint128::new(100),
+                    Decimal256::zero(),
+                    None,
+                )),
+                OrderOperation::PlaceLimit(LimitOrder::new(
+                    1,
+                    1,
+                    OrderDirection::Ask,
+                    Addr::unchecked("owner"),
+                    Uint128::new(200),
+                    Decimal256::zero(),
+                    None,
+                )),
+                OrderOperation::PlaceLimit(LimitOrder::new(
+                    1,
+                    2,
+                    OrderDirection::Bid,
+                    Addr::unchecked("owner"),
+                    Uint128::new(100),
+                    Decimal256::zero(),
+                    None,
+                )),
+            ],
+            expected_output: vec![LimitOrder::new(
+                1,
+                0,
+                OrderDirection::Bid,
+                Addr::unchecked("owner"),
+                Uint128::new(100),
+                Decimal256::zero(),
+                None,
+            )],
+            expected_count: 1,
+            tick_id: 1,
+            limit: Some(2),
+            start_from: None,
+            end_at: Some(0),
+            expected_error: None,
+        },
+    ];
+
+    for test in test_cases {
+        // -- Test Setup --
+        let mut deps = mock_dependencies_custom();
+        let env = mock_env();
+        let info = mock_info(DEFAULT_SENDER, &[]);
+
+        create_orderbook(
+            deps.as_mut(),
+            QUOTE_DENOM.to_string(),
+            BASE_DENOM.to_string(),
+        )
+        .unwrap();
+
+        for operation in test.pre_operations {
+            operation
+                .run(deps.as_mut(), env.clone(), info.clone())
+                .unwrap();
+        }
+
+        // -- System under test --
+        let res = query::orders_by_tick(
+            deps.as_ref(),
+            test.tick_id,
+            test.start_from,
+            test.end_at,
+            test.limit,
+        );
+
+        if let Some(err) = test.expected_error {
+            assert_eq!(
+                res.unwrap_err(),
+                err,
+                "{}: did not receive expected error",
+                test.name
+            );
+
+            continue;
+        }
+
+        let res = res.unwrap_or_else(|_| {
+            panic!(
+                "{}: orders_by_owner returned an unexpected error",
+                test.name
+            );
+        });
+        assert_eq!(
+            res.orders, test.expected_output,
+            "{}: output did not match",
+            test.name
+        );
+        assert_eq!(
+            res.count, test.expected_count,
+            "{}: count did not match",
+            test.name
+        );
+    }
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change
This change adds a useful query that allows a user to query (in paginated fashion) all orders for a given tick.

## Testing and Verifying
A unit test was added for the query and can be run using:

```
cargo unit-test test_orders_by_tick
```