### PR TITLE
[Sumtree]: Add defense in depth check to swap steps

### DIFF
--- a/contracts/sumtree-orderbook/src/order.rs
+++ b/contracts/sumtree-orderbook/src/order.rs
@@ -557,6 +557,14 @@ pub(crate) fn run_market_order_internal(
             tick_price,
             RoundingDirection::Up,
         )?;
+
+        ensure!(
+            !input_filled.is_zero(),
+            ContractError::InvalidSwap {
+                error: "Input amount for a given swap step cannot be zero".to_string()
+            }
+        );
+
         order.quantity = order
             .quantity
             // Safe conversions as amount filled should never be larger than order quantity which is upper bounded by Uint128::MAX


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

While reviewing rounding behavior, we concluded that the rounding related issues we were worried about do not seem to be exploitable. That being said, the candidate attack vectors we were considering hinged on the fact that the nonzero input check only triggered at the beginning of the swap as opposed to during every swap step.

This PR adds a defense in depth check to ensure there can never be a swap step that proceeds after consuming zero input.

## Testing and Verifying

This code path should not be possible to hit and is thus difficult to construct a unit test for, but should be covered thoroughly by our fuzz tests.